### PR TITLE
Ability to configure the cache backends

### DIFF
--- a/gapipy/cache.py
+++ b/gapipy/cache.py
@@ -48,7 +48,7 @@ class BaseCache(object):
                             specified on :meth:`set`.
     """
 
-    def __init__(self, default_timeout=300):
+    def __init__(self, default_timeout=300, **kwargs):
         self.default_timeout = default_timeout
 
     def get(self, resource_name, resource_id=None):
@@ -88,7 +88,7 @@ class SimpleCache(BaseCache):
     :param threshold: the maximum number of items the cache stores before
                       it starts evicting keys.
     """
-    def __init__(self, threshold=500, default_timeout=300):
+    def __init__(self, threshold=500, default_timeout=300, **kwargs):
         BaseCache.__init__(self, default_timeout)
         self._cache = {}
         self._threshold = threshold
@@ -131,7 +131,7 @@ class RedisCache(BaseCache):
     """Uses the Redis key-value store as a cache backend.
     """
     def __init__(self, host='localhost', port=6379, password=None,
-                 db=0, default_timeout=300, key_prefix=None):
+                 db=0, default_timeout=300, key_prefix=None, **kwargs):
         BaseCache.__init__(self, default_timeout)
         self.key_prefix = key_prefix or ''
         try:

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -16,6 +16,7 @@ default_config = {
     'api_proxy': os.environ.get('GAPI_API_PROXY', ''),
     'api_language': os.environ.get('GAPI_LANGUAGE', 'en'),
     'cache_backend': os.environ.get('GAPI_CACHE_BACKEND', 'gapipy.cache.SimpleCache'),
+    'cache_options': {'threshold': 500, 'default_timeout': 3600},
     'debug': os.environ.get('GAPI_CLIENT_DEBUG', False),
 }
 
@@ -41,7 +42,7 @@ class Client(object):
         self.logger = logger
         self.logger.setLevel(log_level)
 
-        self._set_cache_instance()
+        self._set_cache_instance(get_config(config, 'cache_options'))
 
         # Prevent install issues where setup.py digs down the path and
         # eventually fails on a missing requests requirement by importing Query
@@ -50,11 +51,11 @@ class Client(object):
         for resource in get_available_resource_classes():
             setattr(self, resource._resource_name, Query(self, resource))
 
-    def _set_cache_instance(self):
+    def _set_cache_instance(self, cache_options):
         cache_backend = self.cache_backend
         module_name, class_name = cache_backend.rsplit('.', 1)
         module = import_module(module_name)
-        cache = getattr(module, class_name)()
+        cache = getattr(module, class_name)(**cache_options)
         self._cache = cache
 
     def query(self, resource_name):


### PR DESCRIPTION
The Client initializes the cache, however there was
no means to pass along configuration settings. This change
introduces `cache_options` which is a dictionary passed
as keyword arguments to the `cache_backend` class.

A downside to this approach is that the rest of
the config can optionally use environment variables.
