### PR TITLE
Fix issue with Null valued models.

### DIFF
--- a/gapipy/models/base.py
+++ b/gapipy/models/base.py
@@ -107,7 +107,10 @@ class BaseModel(object):
         return model_cls
 
     def _set_model_field(self, field, value):
-        setattr(self, field, self._model_cls(field)(value))
+        if value is None:
+            setattr(self, field, None)
+        else:
+            setattr(self, field, self._model_cls(field)(value))
 
     def _set_model_collection_field(self, field, value):
         model_cls = self._model_cls(field)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -105,6 +105,22 @@ class ResourceTestCase(TestCase):
         self.assertEquals(f.bar.id, 1)
         self.assertEquals(f.bar.date, datetime.datetime(2013, 01, 01))
 
+    def test_null_model_fields(self):
+        from gapipy.models.base import BaseModel
+
+        class Bar(BaseModel):
+            _as_is_fields = ['id']
+            _date_fields = ['date']
+
+        class Foo(Resource):
+            _model_fields = [('bar', Bar)]
+
+        data = {
+            'bar': None
+        }
+        f = Foo(data)
+
+        self.assertEquals(f.bar, None)
 
 class AccommodationRoomTestCase(TestCase):
 


### PR DESCRIPTION
If a model had a value of None, gapipy would error out.
