### PR TITLE
Check for None values instead of falsy values in GET request validation

### DIFF
--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -88,7 +88,7 @@ class APIRequestor(object):
     def get(self, resource_id=None, uri=None):
         """Get a single resource with the given resource_id or uri"""
 
-        if not (resource_id or uri):
+        if resource_id is None and uri is None:
             raise ValueError(
                 'Need to provide at least one of `resource_id` or `uri` as argument')
         if not uri:

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -19,6 +19,17 @@ class APIRequestorTestCase(unittest.TestCase):
         requestor.get(1234)
         mock_request.assert_called_once_with('/resources/1234', 'GET')
 
+    def test_get_with_null_resource_id_and_uri_raises_error(self, mock_request):
+        requestor = APIRequestor(self.client, 'resources')
+        error_msg = 'Need to provide at least one of `resource_id` or `uri` as argument'
+        with self.assertRaisesRegexp(ValueError, error_msg):
+            requestor.get()
+
+    def test_get_with_falsy_resource_id_does_not_raise_error(self, mock_request):
+        requestor = APIRequestor(self.client, 'resources')
+        requestor.get(0)
+        mock_request.assert_called_once_with('/resources/0', 'GET')
+
     def test_list_resource(self, mock_request):
         requestor = APIRequestor(self.client, 'resources')
         requestor.list_raw()
@@ -39,7 +50,7 @@ class APIRequestorTestCase(unittest.TestCase):
             call('http://localhost:5000/resources/?page=2'),
         ]
 
-        requestor = APIRequestor(self.client, 'resource')
+        requestor = APIRequestor(self.client, 'resources')
         resources = list(requestor.list())
 
         self.assertEqual(mock_list.mock_calls, expected_calls)


### PR DESCRIPTION
If `APIRequestor.get` is called with `resource_id=0, uri=None`, it should make
a request for that id instead of raising a ValueError for an empty input.