### PR TITLE
Add itineraries.details list

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,11 @@
 History
 -------
 
-0.4.3 (2015-11-03)
+0.4.3 (2015-11-04)
 -------------------
 
 * Added the ``tour_dossier`` field to the ``Itinerary`` resource.
+* Added the ``details`` field to the ``Itinerary`` resource -- a list of textual details about an itinerary.
 
 0.4.2 (2015-10-28)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,11 +3,15 @@
 History
 -------
 
-0.4.3 (2015-11-04)
+0.4.4 (2015-11-04)
+------------------
+
+* Added the ``details`` field to the ``Itinerary`` resource -- a list of textual details about an itinerary.
+
+0.4.3 (2015-11-03)
 -------------------
 
 * Added the ``tour_dossier`` field to the ``Itinerary`` resource.
-* Added the ``details`` field to the ``Itinerary`` resource -- a list of textual details about an itinerary.
 
 0.4.2 (2015-10-28)
 ------------------

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 __title__ = 'gapipy'
 
 

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.4.2'
+__version__ = '0.4.3'
 __title__ = 'gapipy'
 
 

--- a/gapipy/resources/tour/itinerary.py
+++ b/gapipy/resources/tour/itinerary.py
@@ -84,6 +84,24 @@ class ValidDuringRange(BaseModel):
         return '<{} ({} - {})>'.format(self.__class__.__name__, self.start_date, self.end_date)
 
 
+class DetailType(BaseModel):
+    _as_is_fields = ['id', 'name']
+
+    def __repr__(self):
+        return '<{} {}>'.format(self.__class__.__name__, self.name)
+
+
+class Detail(BaseModel):
+    _as_is_fields = ['body']
+
+    _model_fields = [
+        ('type', DetailType),
+    ]
+
+    def __repr__(self):
+        return '<{} {}: {}>'.format(self.__class__.__name__, self.type.name, self.body[:100])
+
+
 class Itinerary(Resource):
 
     _resource_name = 'itineraries'
@@ -99,6 +117,7 @@ class Itinerary(Resource):
     ]
     _model_collection_fields = [
         ('days', ItineraryDay),
+        ('details', Detail),
         ('variations', 'Itinerary'),
         ('valid_during_ranges', ValidDuringRange),
     ]


### PR DESCRIPTION
https://trello.com/c/cTwvVe92/284-add-details-to-itineraryversions

Depends on [gadventures.com PR389](https://github.com/gadventures/gadventures.com/pull/389) and [gapi-layer PR45](https://github.com/gadventures/gapi-layer/pull/45) -- see that one or the Trello card for details.