### PR TITLE
Remove global client; refactor cache backends

### DIFF
--- a/gapipy/cache.py
+++ b/gapipy/cache.py
@@ -1,28 +1,11 @@
 import collections
-from functools import partial
 from time import time
 
-from gapipy import client as client_module
 
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
-
-
-def make_key(resource_name, resource_id=None, variation_id=None):
-    if not resource_id:
-        return resource_name
-
-    current_client = client_module.current_client
-
-    parts = [resource_name, str(resource_id)]
-    if variation_id:
-        parts.append(str(variation_id))
-
-    if current_client.api_language:
-        parts.append(current_client.api_language)
-    return ':'.join(parts)
 
 
 def update(d, u):
@@ -56,25 +39,16 @@ class BaseCache(object):
     :param default_timeout: the default timeout that is used if no timeout is
                             specified on :meth:`set`.
     """
-
     def __init__(self, default_timeout=300, **kwargs):
         self.default_timeout = default_timeout
 
-    def get(self, resource_name, resource_id=None, variation_id=None):
+    def get(self, key):
         return None
 
-    def set(self, resource_name, data_dict):
+    def set(self, key, value):
         pass
 
-    def set_many(self, resource_name, sequence, timeout=None):
-        for data_dict in sequence:
-            self.set(resource_name, data_dict, timeout)
-
-    def get_many(self, resource_name, ids):
-        func = partial(self.get, resource_name)
-        return map(func, ids)
-
-    def delete(self, resource_name, resource_id=None):
+    def delete(self, key):
         pass
 
     def clear(self):
@@ -83,7 +57,7 @@ class BaseCache(object):
     def count(self):
         raise NotImplementedError
 
-    def is_cached(self, resource_name, resource_id):
+    def is_cached(self, key):
         return False
 
 
@@ -113,24 +87,19 @@ class SimpleCache(BaseCache):
                 if expires <= now or idx % 3 == 0:
                     self._cache.pop(key, None)
 
-    def get(self, resource_name, resource_id=None, variation_id=None):
-        key = make_key(resource_name, resource_id, variation_id)
+    def get(self, key):
         expires, value = self._cache.get(key, (0, None))
         if expires > time():
             return pickle.loads(value)
 
-    def set(self, resource_name, data_dict, timeout=None):
-        key = make_key(resource_name,
-            data_dict.get('id'), data_dict.get('variation_id'))
+    def set(self, key, data_dict, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
         self._prune()
-
         self._cache[key] = (time() + timeout, pickle.dumps(data_dict,
                             pickle.HIGHEST_PROTOCOL))
 
-    def delete(self, resource_name, resource_id=None, variation_id=None):
-        key = make_key(resource_name, resource_id, variation_id)
+    def delete(self, key):
         return self._cache.pop(key, None)
 
     def clear(self):
@@ -139,8 +108,7 @@ class SimpleCache(BaseCache):
     def count(self):
         return len(self._cache)
 
-    def is_cached(self, resource_name, resource_id, variation_id=None):
-        key = make_key(resource_name, resource_id, variation_id)
+    def is_cached(self, key):
         return key in self._cache
 
 
@@ -167,20 +135,16 @@ class RedisCache(BaseCache):
     def dump_object(self, value):
         return pickle.dumps(value)
 
-    def get(self, resource_name, resource_id=None, variation_id=None):
-        key = make_key(resource_name, resource_id, variation_id)
+    def get(self, key):
         return self.load_object(self._client.get(self.key_prefix + key))
 
-    def set(self, resource_name, data_dict, timeout=None):
-        key = make_key(resource_name,
-            data_dict.get('id', None), data_dict.get('variation_id'))
+    def set(self, key, data_dict, timeout=None):
         if timeout is None:
             timeout = self.default_timeout
         data = self.dump_object(data_dict)
         return self._client.setex(self.key_prefix + key, data, timeout)
 
-    def delete(self, resource_name, resource_id=None, variation_id=None):
-        key = make_key(resource_name, resource_id, variation_id)
+    def delete(self, key):
         return self._client.delete(self.key_prefix + key)
 
     def clear(self):
@@ -190,6 +154,5 @@ class RedisCache(BaseCache):
     def info(self):
         return self._client.info()
 
-    def is_cached(self, resource_name, resource_id, variation_id=None):
-        key = make_key(resource_name, resource_id, variation_id)
+    def is_cached(self, key):
         return self._client.exists(self.key_prefix + key)

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -6,9 +6,6 @@ from importlib import import_module
 
 from .utils import get_available_resource_classes
 
-
-current_client = None
-
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 
@@ -28,6 +25,7 @@ default_config = {
     },
 }
 
+
 def _get_protocol_prefix(api_root):
     """
     Returns the protocol plus "://" of api_root.
@@ -37,6 +35,7 @@ def _get_protocol_prefix(api_root):
     match = re.search(r'^[^:/]*://', api_root)
     return match.group(0) if match else ''
 
+
 def get_config(config, name):
     return config.get(name, default_config[name])
 
@@ -44,9 +43,6 @@ def get_config(config, name):
 class Client(object):
 
     def __init__(self, **config):
-
-        global current_client
-        current_client = self
 
         self.application_key = get_config(config, 'application_key')
         self.api_root = get_config(config, 'api_root')
@@ -58,7 +54,6 @@ class Client(object):
         # client has specified
         self.connection_pool_options = default_config['connection_pool_options']
         self.connection_pool_options.update(get_config(config, 'connection_pool_options'))
-
 
         log_level = 'DEBUG' if get_config(config, 'debug') else 'ERROR'
         self.logger = logger
@@ -137,7 +132,7 @@ class Client(object):
     def build(self, resource_name, data_dict, **kwargs):
         try:
             resource_cls = getattr(self, resource_name).resource
-            return resource_cls(data_dict, **kwargs)
+            return resource_cls(data_dict, self, **kwargs)
         except AttributeError:
             raise AttributeError("No resource named %s is defined." % resource_name)
 

--- a/gapipy/models/room.py
+++ b/gapipy/models/room.py
@@ -28,8 +28,8 @@ class AccommodationRoom(Room):
     def _model_collection_fields(self):
         return [('price_bands', SeasonalPriceBand)]
 
-    def __init__(self, data):
-        super(AccommodationRoom, self).__init__(data)
+    def __init__(self, data, client):
+        super(AccommodationRoom, self).__init__(data, client)
 
         # `class` is a reserved word in python, so we instead use `room_class`
         # as the attribute for the room class.

--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -46,6 +46,8 @@ class Query(object):
         good method to invalidate persistent cache backend after receiving a
         webhook that a resource has changed.
         """
+        key = self.query_key(resource_id, variation_id)
+
         try:
             data = self.get_resource_data(resource_id,
                 variation_id=variation_id, cached=cached)
@@ -53,8 +55,8 @@ class Query(object):
             if e.response.status_code == 404:
                 return None
             raise e
-        resource_object = self.resource(data)
-        self._client._cache.set(self.resource._resource_name, resource_object.to_dict())
+        resource_object = self.resource(data, self._client)
+        self._client._cache.set(key, resource_object.to_dict())
         return resource_object
 
     def get_resource_data(self, resource_id, variation_id=None, cached=True):
@@ -62,13 +64,10 @@ class Query(object):
         Returns a dictionary of resource data, which is used to initialize
         a Resource object in the `get` method.
         '''
+        key = self.query_key(resource_id, variation_id)
         resource_data = None
         if cached:
-            resource_data = self._client._cache.get(
-                self.resource._resource_name,
-                resource_id,
-                variation_id,
-            )
+            resource_data = self._client._cache.get(key)
             if resource_data is not None:
                 return resource_data
 
@@ -77,18 +76,27 @@ class Query(object):
         return requestor.get(resource_id, variation_id=variation_id)
 
     def purge_cached(self, resource_id, variation_id=None):
-        return self._client._cache.delete(
-            self.resource._resource_name,
-            resource_id,
-            variation_id,
-        )
+        key = self.query_key(resource_id, variation_id)
+        return self._client._cache.delete(key)
 
     def is_cached(self, resource_id, variation_id=None):
-        return self._client._cache.is_cached(
-            self.resource._resource_name,
-            resource_id,
-            variation_id,
-        )
+        key = self.query_key(resource_id, variation_id)
+        return self._client._cache.is_cached(key)
+
+    def query_key(self, resource_id=None, variation_id=None):
+        """Returns a unique key for the information used to fetch the resource(s)
+        in this query. Currently used for creating cache keys.
+        """
+        if not resource_id:
+            return self.resource._resource_name
+
+        parts = [self.resource._resource_name, str(resource_id)]
+        if variation_id:
+            parts.append(str(variation_id))
+        if self._client.api_language:
+            parts.append(self._client.api_language)
+
+        return ':'.join(parts)
 
     @_check_listable
     def all(self, limit=None):
@@ -111,7 +119,7 @@ class Query(object):
                 raise ValueError('`limit` must be a positive integer')
 
         for result in generator:
-            yield self.resource(result, stub=True)
+            yield self.resource(result, self._client, stub=True)
 
     def filter(self, **kwargs):
         """Add filter arguments to the query.

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -13,7 +13,8 @@ class Resource(BaseModel):
     _is_parent_resource = False
     _is_listable = True  # True if resource can be listed/queried (i.e /{resource_name} is an endpoint)
 
-    def __init__(self, data, stub=False, client=None):
+    def __init__(self, data, client, stub=False):
+        assert(client)
         self.is_stub = stub
         super(Resource, self).__init__(data, client)
 
@@ -34,7 +35,7 @@ class Resource(BaseModel):
     def create(cls, client, data_dict):
         request = APIRequestor(client, cls._resource_name)
         response = request.create(json.dumps(data_dict))
-        return cls(response)
+        return cls(response, client)
 
     def __getattr__(self, name):
         # If we try to access a field that's allowed, and this resource is a

--- a/gapipy/resources/tour/promotion.py
+++ b/gapipy/resources/tour/promotion.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from ...utils import get_resource_class_from_resource_name
 from ..base import Resource, Product
 
+
 class PromotionProduct(Resource):
     """
     The `products` referenced in a Promotion object are not valid resources (due
@@ -11,7 +12,7 @@ class PromotionProduct(Resource):
     When the resource is fixed, the hacks here can simply be replaced with
     `gapipy.models.base.RelatedResourceMixin`
     """
-    def __init__(self, data, **kwargs):
+    def __init__(self, data, client, **kwargs):
         # Fetch the resource class using the `type`, and then derive field
         # attributes from that class.
         klass = get_resource_class_from_resource_name(data['type'])
@@ -22,7 +23,8 @@ class PromotionProduct(Resource):
         self._resource_name = data['type']
         self._as_is_fields = self._as_is_fields + ['type', 'sub_type']
 
-        super(PromotionProduct, self).__init__(data, **kwargs)
+        super(PromotionProduct, self).__init__(data, client, **kwargs)
+
 
 class Promotion(Resource):
 
@@ -50,6 +52,6 @@ class Promotion(Resource):
         # Each product can be a different resource, so derive the resource from
         # the "type" within the stubbed object.
         for product in data:
-            stub = PromotionProduct(product, stub=True)
+            stub = PromotionProduct(product, self._client, stub=True)
             product_stubs.append(stub)
         setattr(self, field, product_stubs)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,21 +2,6 @@ import time
 from unittest import TestCase, skipUnless
 
 from gapipy import cache
-from gapipy.cache import make_key
-from gapipy.client import Client
-
-class CacheTestCase(TestCase):
-    def test_make_key(self):
-        Client()
-        self.assertEquals(make_key('foo', 1), 'foo:1')
-
-    def test_make_key_language(self):
-        Client(api_language='de')
-        self.assertEquals(make_key('foo', 1), 'foo:1:de')
-
-    def test_make_key_variation_id(self):
-        Client()
-        self.assertEqual(make_key('foo', 1, 9000), 'foo:1:9000')
 
 
 class SimpleCacheTestCase(TestCase):
@@ -29,36 +14,9 @@ class SimpleCacheTestCase(TestCase):
 
     def test_get_set_resource_id(self):
         c = cache.SimpleCache()
-        c.set('foo', {'id': 100, 'xyz': 'bar'})
-        data = c.get('foo', 100)
+        c.set('foo:100', {'id': 100, 'xyz': 'bar'})
+        data = c.get('foo:100')
         self.assertEquals(data, {'id': 100, 'xyz': 'bar'})
-
-    def test_get_set_resource_and_variation_id(self):
-        c = cache.SimpleCache()
-        c.set('foo', {'id': 100, 'xyz': 'bar', 'variation_id': 9000})
-        data = c.get('foo', 100, 9000)
-        self.assertEquals(data, {'id': 100, 'xyz': 'bar', 'variation_id': 9000})
-
-    def test_get_many_resource_id(self):
-        c = cache.SimpleCache()
-        c.set('a', {'id': 1, 0: 0})
-        c.set('a', {'id': 2, 1: 1})
-
-        self.assertEquals(c.get_many('a', (1, 2)), [
-            {'id': 1, 0: 0},
-            {'id': 2, 1: 1},
-        ])
-
-    def test_set_many(self):
-        c = cache.SimpleCache()
-        c.set_many('foo', [
-            {'id': 1, 0: 0},
-            {'id': 2, 1: 1},
-            {'id': 3, 2: 4},
-        ])
-        self.assertEquals(c.get('foo', 2), {'id': 2, 1: 1})
-        c.set_many('foo', [{'id': 2, 1: 100}])
-        self.assertEquals(c.get('foo', 2), {'id': 2, 1: 100})
 
     def test_delete(self):
         c = cache.SimpleCache()
@@ -92,30 +50,6 @@ class RedisCacheTestCase(TestCase):
 
         c.set('a', {'results': (1, 2, 3)})
         self.assertEquals(c.get('a'), {'results': (1, 2, 3)})
-
-    def test_get_set_resource_and_variation_id(self):
-        c = self.make_cache()
-        c.set('foo', {'id': 100, 'xyz': 'bar', 'variation_id': 9000})
-        data = c.get('foo', 100, 9000)
-        self.assertEquals(data, {'id': 100, 'xyz': 'bar', 'variation_id': 9000})
-
-    def test_get_many(self):
-        c = self.make_cache()
-        c.set('a', {'id': 1})
-        c.set('a', {'id': 2})
-        self.assertEquals(c.get_many('a', (1, 2)), [
-            {'id': 1},
-            {'id': 2},
-        ])
-
-    def test_set_many(self):
-        c = self.make_cache()
-        c.set_many('a', [
-            {'id': 1, 0: 0},
-            {'id': 2, 1: 1},
-            {'id': 3, 2: 4},
-        ])
-        self.assertEquals(c.get('a', 3), {'id': 3, 2: 4})
 
     def test_expire(self):
         c = self.make_cache()

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from mock import patch
 
+from gapipy.client import Client
 from gapipy.query import Query
 from gapipy.models import DATE_FORMAT, AccommodationRoom
 from gapipy.resources import Tour, TourDossier, Promotion
@@ -13,8 +14,11 @@ from .fixtures import PPP_TOUR_DATA, PPP_DOSSIER_DATA
 
 class ResourceTestCase(TestCase):
 
+    def setUp(self):
+        self.client = Client()
+
     def test_to_dict(self):
-        t = Tour(PPP_TOUR_DATA)
+        t = Tour(PPP_TOUR_DATA, self.client)
         self.assertEquals(t.to_dict(), PPP_TOUR_DATA)
 
     def test_to_dict_datetimes(self):
@@ -27,14 +31,14 @@ class ResourceTestCase(TestCase):
             'id': 1,
             'date_field': '2013-02-18',
             'date_field_utc': '2013-02-18T18:17:20Z',
-        })
+        }, self.client)
         data = resource.to_dict()
         self.assertEquals(data['date_field'], '2013-02-18')
         self.assertEquals(data['date_field_utc'], '2013-02-18T18:17:20Z')
 
     @patch('gapipy.request.APIRequestor._request', return_value=PPP_DOSSIER_DATA)
     def test_instantiate_from_raw_data(self, mock_request):
-        t = Tour(PPP_TOUR_DATA)
+        t = Tour(PPP_TOUR_DATA, self.client)
         self.assertIsInstance(t, Tour)
         self.assertEqual(t.product_line, 'PPP')
         self.assertIsInstance(t.departures_start_date, datetime.date)
@@ -59,7 +63,7 @@ class ResourceTestCase(TestCase):
         }
         data = {'id': 1, 'product_line': 'PPP'}
 
-        t = Tour(data, stub=True)
+        t = Tour(data, self.client, stub=True)
         self.assertTrue(t.is_stub)
         self.assertEquals(t.id, 1)
 
@@ -96,7 +100,7 @@ class ResourceTestCase(TestCase):
                 'date': '2013-01-01',
             }
         }
-        f = Foo(data)
+        f = Foo(data, self.client)
 
         self.assertEquals(f.to_dict(), {
             'bar': {'id': 1, 'date': '2013-01-01'}
@@ -118,11 +122,15 @@ class ResourceTestCase(TestCase):
         data = {
             'bar': None
         }
-        f = Foo(data)
+        f = Foo(data, self.client)
 
         self.assertEquals(f.bar, None)
 
+
 class AccommodationRoomTestCase(TestCase):
+
+    def setUp(self):
+        self.client = Client()
 
     def test_room_class_is_set_properly(self):
         data = {
@@ -132,7 +140,7 @@ class AccommodationRoomTestCase(TestCase):
             'price_bands': [],
             'class': 'Standard',
         }
-        room = AccommodationRoom(data)
+        room = AccommodationRoom(data, self.client)
         self.assertEqual(room.room_class, 'Standard')
 
     def test_room_class_is_set_properly_when_cached(self):
@@ -143,10 +151,15 @@ class AccommodationRoomTestCase(TestCase):
             'price_bands': [],
             'room_class': 'Standard',
         }
-        room = AccommodationRoom(data)
+        room = AccommodationRoom(data, self.client)
         self.assertEqual(room.room_class, 'Standard')
 
+
 class PromotionTestCase(TestCase):
+
+    def setUp(self):
+        self.client = Client()
+
     @patch('gapipy.request.APIRequestor._request')
     def test_product_type_is_set_properly(self, mock_request):
         data = {
@@ -159,7 +172,7 @@ class PromotionTestCase(TestCase):
             ],
         }
 
-        promotion = Promotion(data)
+        promotion = Promotion(data, self.client)
         product = promotion.products[0]
         self.assertEqual(product.type, 'departures')
         self.assertEqual(product.to_dict(), {


### PR DESCRIPTION
The `global` current client that was used by resources and queries was
not safe for use with multiple client instances, except for short-lived
clients. With the language being dynamically detected from the client,
it resulted in timing issues and invalid language retrieval. The fix does
involve requiring the client to be passed to all `BaseModel` instantiation.
I would like to look for a way to avoid this. It seems unnecessary for the 
models to need to know about the client. The only use of the `client` 
within the base model seems to be in `_set_resource_collection_field`
for creating new `Query` objects.

This change also removes the need for the cache backends to know
anything about the query data. Prior to this, we were passing data required to
generate a cache key to the backend – this introduces unnecessary state. 
Instead the `Query` object is now responsible for generating cache keys
(see `query_key`) since it is aware of all needed data and has always
interacted with the cache backends.