### PR TITLE
Fix missing 'amount' key in promo dict

### DIFF
--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -20,4 +20,5 @@ class PricePromotion(Resource):
         super(PricePromotion, self).__init__(data, **kwargs)
 
         # Add the "fake" amount field.
+        self._price_fields.append('amount')
         setattr(self, 'amount', data['amount'])

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -435,43 +435,85 @@ DUMMY_DEPARTURE = {
                     "min_age": 12,
                     "prices": [
                         {
-                            "promotions": [],
+                            "promotions": [
+                                {
+                                    "amount": "2199.20",
+                                    "href": "https://rest.gadventures.com/promotions/48500",
+                                    "id": "48500"
+                                },
+                            ],
                             "currency": "AUD",
                             "amount": "2999.00",
                             "deposit": "250.00"
                         },
                         {
-                            "promotions": [],
+                            "promotions": [
+                                {
+                                    "amount": "2199.20",
+                                    "href": "https://rest.gadventures.com/promotions/48500",
+                                    "id": "48500"
+                                },
+                            ],
                             "currency": "CAD",
                             "amount": "3299.00",
                             "deposit": "250.00"
                         },
                         {
-                            "promotions": [],
+                            "promotions": [
+                                {
+                                    "amount": "2199.20",
+                                    "href": "https://rest.gadventures.com/promotions/48500",
+                                    "id": "48500"
+                                },
+                            ],
                             "currency": "CHF",
                             "amount": "2949.00",
                             "deposit": "250.00"
                         },
                         {
-                            "promotions": [],
+                            "promotions": [
+                                {
+                                    "amount": "2199.20",
+                                    "href": "https://rest.gadventures.com/promotions/48500",
+                                    "id": "48500"
+                                },
+                            ],
                             "currency": "EUR",
                             "amount": "2149.00",
                             "deposit": "250.00"
                         },
                         {
-                            "promotions": [],
+                            "promotions": [
+                                {
+                                    "amount": "2199.20",
+                                    "href": "https://rest.gadventures.com/promotions/48500",
+                                    "id": "48500"
+                                },
+                            ],
                             "currency": "GBP",
                             "amount": "1749.00",
                             "deposit": "100.00"
                         },
                         {
-                            "promotions": [],
+                            "promotions": [
+                                {
+                                    "amount": "2199.20",
+                                    "href": "https://rest.gadventures.com/promotions/48500",
+                                    "id": "48500"
+                                },
+                            ],
                             "currency": "NZD",
                             "amount": "3999.00",
                             "deposit": "250.00"
                         },
                         {
-                            "promotions": [],
+                            "promotions": [
+                                {
+                                    "amount": "2199.20",
+                                    "href": "https://rest.gadventures.com/promotions/48500",
+                                    "id": "48500"
+                                },
+                            ],
                             "currency": "USD",
                             "amount": "3099.00",
                             "deposit": "250.00"

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -5,10 +5,15 @@ from mock import patch
 
 from gapipy.query import Query
 from gapipy.models import DATE_FORMAT, AccommodationRoom
-from gapipy.resources import Tour, TourDossier, Promotion
+from gapipy.resources import (
+    Departure,
+    Promotion,
+    Tour,
+    TourDossier,
+)
 from gapipy.resources.base import Resource
 
-from .fixtures import PPP_TOUR_DATA, PPP_DOSSIER_DATA
+from .fixtures import DUMMY_DEPARTURE, PPP_TOUR_DATA, PPP_DOSSIER_DATA
 
 
 class ResourceTestCase(TestCase):
@@ -180,3 +185,12 @@ class PromotionTestCase(TestCase):
         }
         self.assertEqual(product.finish_address.country.name, 'Australia')
         self.assertEqual(product.type, 'departures')
+
+
+class PricePromotionTestCase(TestCase):
+    def test_fake_amount_is_set_properly(self):
+        departure = Departure(DUMMY_DEPARTURE)
+        prices = departure.rooms[0].price_bands[0].prices
+        for price in prices:
+            promotion = price.promotions[0].to_dict()
+            self.assertTrue('amount' in promotion)


### PR DESCRIPTION
It seemed like the fake 'amount' key that gets [added to nested promotions](https://github.com/gadventures/gapipy/blob/843d473f0301d814a24e46d5f3536f6b46013f71/gapipy/models/price_promotion.py#L22) was not working. When I retrieved stuff through gapipy that key was missing even though it was present in the raw API response.

Just needed to be declared as a field for gapipy to remember to serialize it.

*Might* be related to https://app.getsentry.com/gadventures/gadv-com/group/88033417/

@bartek I messed with your `DUMMY_DEPARTURE` fixture, hope that that is ok (all the other tests still pass.)