### PR TITLE
Adds connection pool sharing in RedisCache

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 History
 -------
 
+0.4.6 (2015-12-09)
+------------------
+
+* Added connection pool caching to ``RedisCache``. Instances of ``gapipy`` with the same cache settings (in the same Python process) will share a connection pool.
+
 0.4.5 (2015-11-05)
 ------------------
 

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '0.4.5'
+__version__ = '0.4.6'
 __title__ = 'gapipy'
 
 


### PR DESCRIPTION
Previously each instantiation would create a `redis.Redis` client which
would create it's own connection pool. This was causing us to run out of
file handles in certain situations.