### PR TITLE
Resource list stubs

### DIFF
--- a/gapipy/models/base.py
+++ b/gapipy/models/base.py
@@ -114,20 +114,22 @@ class BaseModel(object):
             setattr(self, field, self._model_cls(field)(value))
 
     def _set_model_collection_field(self, field, value):
+        from gapipy.resources.base import Resource
+
         model_cls = self._model_cls(field)
-        items = [model_cls(m) for m in value]
+
+        if issubclass(model_cls, Resource):
+            items = [model_cls(m, stub=True) for m in value]
+        else:
+            items = [model_cls(m) for m in value]
+
         setattr(self, field, items)
 
     def _set_resource_field(self, field, value):
-        stub = None
-
-        if isinstance(value, list):
-            stub = []
-            for v in value:
-                stub.append(self._model_cls(field)(v, stub=True))
-        elif value:
-            stub = self._model_cls(field)(value, stub=True)
-        setattr(self, field, stub)
+        if value is None:
+            setattr(self, field, None)
+        else:
+            setattr(self, field, self._model_cls(field)(value, stub=True))
 
     def _set_resource_collection_field(self, field, value):
         is_parent_resource = getattr(self, '_is_parent_resource', None)

--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -25,20 +25,16 @@ class TourDossier(Resource):
     _resource_fields = [('tour', 'Tour')]
     _resource_collection_fields = [
         ('departures', 'Departure'),
-        ('structured_itineraries', 'Itinerary'),
     ]
     _model_collection_fields = [
         ('advertised_departures', AdvertisedDeparture),
+        ('structured_itineraries', 'Itinerary'),
     ]
 
     def _set_resource_collection_field(self, field, value):
         """Overridden to ensure that the `departures` query has the right
-        parent resource (i.e. the tour and not the tour dossier), and to handle
-        the special case of structured itineraries being an associated resource
-        that is not a child resource.
+        parent resource (i.e. the tour and not the tour dossier).
         """
-
-        from .itinerary import Itinerary
 
         if field == 'departures':
             resource_cls = get_resource_class_from_class_name('Departure')
@@ -47,11 +43,6 @@ class TourDossier(Resource):
             parent = ('tours', self.id, None)
 
             setattr(self, 'departures', Query(self._client, resource_cls, parent=parent, raw_data=value))
-
-        elif field == 'structured_itineraries':
-            itineraries = [Itinerary(i, stub=True) for i in value]
-            setattr(self, 'structured_itineraries', itineraries)
-
         else:
             return super(TourDossier, self)._set_resource_collection_field(field, value)
 


### PR DESCRIPTION
Resources that are referred to from other resources are not inlined in their
entirety. Often, only their `id` and `href` will be inlined, and an extra API
call has to be made in order to retrieve all the data of the subresource.

In gapipy, we abstract over these details, by making all references to
resources either a Resource object, a Query object, or a plain Python list of
Resource objects. Internally, instantiated resources that aren't complete are
considered as "stubs". If a missing field is accessed and the resource is a
stub, then the full resource is fetched in the background, and the data is
returned transparently.

List of non-child resources were not properly instantiated as stubs, which
meant that accessing missing fields would raise an AttributeError, instead of
fetching it from the API.