### PR TITLE
Add dossier ids to itinerary media and highlights

### DIFF
--- a/gapipy/resources/tour/itinerary.py
+++ b/gapipy/resources/tour/itinerary.py
@@ -112,7 +112,7 @@ class ItineraryMedia(Resource):
     _resource_name = 'itinerary_media'
 
     _as_is_fields = [
-        'type', 'video_thumb', 'videos', 'image',
+        'id', 'type', 'video_thumb', 'videos', 'image',
     ]
 
     def __repr__(self):
@@ -122,7 +122,7 @@ class ItineraryMedia(Resource):
 class ItineraryHighlights(Resource):
     _resource_name = 'itinerary_highlights'
 
-    _as_is_fields = ['name', 'description', 'media']
+    _as_is_fields = ['id', 'name', 'description', 'media']
 
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)


### PR DESCRIPTION
A new feature has been added to gadventures linking dossiers and content
pages; however, we do not want the content pages associated with gapi.
There is a foreign key that exists between contentpages and dossiers,
but since the content pages do not exist in gapi, we need to re-establish
this relationship. We can do that by exposing the dossier_ids on itinerary-highlights.
The information already exists in gapi-layer, it simply needs to be exposed through gapipy.

As we begin to disassociate dossiers, and other structured data, from the api we'll
need to adopt this pattern of loose relationships more frequently.