### PR TITLE
Force the output of __repr__ to be of the proper string type

### DIFF
--- a/gapipy/models/addon.py
+++ b/gapipy/models/addon.py
@@ -1,4 +1,5 @@
 from .base import BaseModel, RelatedResourceMixin
+from ..utils import enforce_string_type
 
 
 class AddOn(BaseModel, RelatedResourceMixin):
@@ -6,6 +7,7 @@ class AddOn(BaseModel, RelatedResourceMixin):
     _date_fields = ['start_date', 'finish_date', 'halt_booking_date', 'request_space_date']
     _resource_fields = []
 
+    @enforce_string_type
     def __repr__(self):
         return '<{0} ({1})>'.format(self.__class__.__name__, self.product.name)
 

--- a/gapipy/models/address.py
+++ b/gapipy/models/address.py
@@ -1,4 +1,5 @@
 from .base import BaseModel
+from ..utils import enforce_string_type
 
 
 class Address(BaseModel):
@@ -8,6 +9,7 @@ class Address(BaseModel):
         ('country', 'Country')
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{0}: {1}, {2}>'.format(
             self.__class__.__name__, self.city, self.country.name)

--- a/gapipy/models/base.py
+++ b/gapipy/models/base.py
@@ -4,6 +4,7 @@ import datetime
 
 from gapipy.query import Query
 from gapipy.utils import (
+    enforce_string_type,
     get_resource_class_from_class_name,
     get_resource_class_from_resource_name,
 )
@@ -245,6 +246,7 @@ class DictToModel(object):
     def __str__(self):
         return self._class_name
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}>'.format(self.__str__())
 

--- a/gapipy/models/room.py
+++ b/gapipy/models/room.py
@@ -1,6 +1,7 @@
 from .addon import AddOn
 from .price_band import PriceBand, SeasonalPriceBand
 from .base import BaseModel
+from ..utils import enforce_string_type
 
 
 class Room(BaseModel):
@@ -10,6 +11,7 @@ class Room(BaseModel):
     def _model_collection_fields(self):
         return [('price_bands', PriceBand)]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{0} ({1})>'.format(self.__class__.__name__, self.name)
 

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -1,7 +1,10 @@
+from __future__ import unicode_literals
+
 import json
 import logging
 from gapipy.request import APIRequestor
 from gapipy.models.base import BaseModel
+from gapipy.utils import enforce_string_type
 
 
 logger = logging.getLogger(__name__)
@@ -45,6 +48,7 @@ class Resource(BaseModel):
 
         raise AttributeError("%r has no field %r available" % (type(self).__name__, name))
 
+    @enforce_string_type
     def __repr__(self):
         if self.is_stub:
             return '<{}: {} (stub)>'.format(self.__class__.__name__, self.id)

--- a/gapipy/resources/booking/nationality.py
+++ b/gapipy/resources/booking/nationality.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from ..base import Resource
+from ...utils import enforce_string_type
 
 
 class Nationality(Resource):
@@ -9,5 +10,6 @@ class Nationality(Resource):
 
     _as_is_fields = ['id', 'href', 'name']
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)

--- a/gapipy/resources/dossier/activity_dossier.py
+++ b/gapipy/resources/dossier/activity_dossier.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from ..base import Resource
 from .details import DossierDetail, DossierDetailsMixin
-from ...utils import humanize_price, LocationLabelMixin, DurationLabelMixin
+from ...utils import humanize_price, LocationLabelMixin, DurationLabelMixin, enforce_string_type
 
 
 class ActivityDossier(Resource, DossierDetailsMixin, DurationLabelMixin, LocationLabelMixin):
@@ -30,6 +30,7 @@ class ActivityDossier(Resource, DossierDetailsMixin, DurationLabelMixin, Locatio
         ('details', DossierDetail),
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, self.name)
 

--- a/gapipy/resources/dossier/details.py
+++ b/gapipy/resources/dossier/details.py
@@ -1,11 +1,13 @@
 from __future__ import unicode_literals
 
 from ...models.base import BaseModel
+from ...utils import enforce_string_type
 
 
 class DossierDetailType(BaseModel):
     _as_is_fields = ['code', 'label', 'description']
 
+    @enforce_string_type
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, self.label)
 
@@ -17,6 +19,7 @@ class DossierDetail(BaseModel):
         ('detail_type', DossierDetailType),
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, self.detail_type)
 

--- a/gapipy/resources/geo/state.py
+++ b/gapipy/resources/geo/state.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from ..base import Resource
+from ...utils import enforce_string_type
 
 
 class State(Resource):
@@ -10,5 +11,6 @@ class State(Resource):
     _as_is_fields = ['id', 'href', 'name']
     _resource_fields = [('country', 'Country')]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)

--- a/gapipy/resources/language.py
+++ b/gapipy/resources/language.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from .base import Resource
+from ..utils import enforce_string_type
 
 
 class Language(Resource):
@@ -9,5 +10,6 @@ class Language(Resource):
 
     _as_is_fields = ['id', 'href', 'name', 'iso_639_3', 'iso_639_1']
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)

--- a/gapipy/resources/tour/accommodation.py
+++ b/gapipy/resources/tour/accommodation.py
@@ -4,6 +4,7 @@ from ...models import Address
 
 from ..base import Product
 from ..dossier import AccommodationDossier
+from ...utils import enforce_string_type
 
 
 class Accommodation(Product):
@@ -20,15 +21,15 @@ class Accommodation(Product):
     def _model_collection_fields(self):
         from ...models import AccommodationRoom
         return [
-           ('rooms', AccommodationRoom), 
+            ('rooms', AccommodationRoom),
         ]
 
     @property
     def _resource_fields(self):
         return [
-           ('accommodation_dossier', AccommodationDossier),
+            ('accommodation_dossier', AccommodationDossier),
         ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)
-

--- a/gapipy/resources/tour/itinerary.py
+++ b/gapipy/resources/tour/itinerary.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from ..base import Resource
 from ...models.base import BaseModel
-from ...utils import DurationLabelMixin, LocationLabelMixin, duration_label
+from ...utils import DurationLabelMixin, LocationLabelMixin, duration_label, enforce_string_type
 
 
 class OptionalActivity(BaseModel):
@@ -11,6 +11,7 @@ class OptionalActivity(BaseModel):
         ('activity_dossier', 'ActivityDossier'),
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.activity_dossier)
 
@@ -20,6 +21,7 @@ class Duration(BaseModel):
         'min_hr', 'max_hr',
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {},{}>'.format(self.__class__.__name__, self.min_hr, self.max_hr)
 
@@ -45,6 +47,7 @@ class ItineraryComponent(BaseModel, DurationLabelMixin, LocationLabelMixin):
         ('duration', 'Duration'),
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.type)
 
@@ -78,6 +81,7 @@ class ItineraryDay(BaseModel):
         ('optional_activities', OptionalActivity),
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, self.day)
 
@@ -85,6 +89,7 @@ class ItineraryDay(BaseModel):
 class ValidDuringRange(BaseModel):
     _date_fields = ['start_date', 'end_date']
 
+    @enforce_string_type
     def __repr__(self):
         return '<{} ({} - {})>'.format(self.__class__.__name__, self.start_date, self.end_date)
 
@@ -92,6 +97,7 @@ class ValidDuringRange(BaseModel):
 class DetailType(BaseModel):
     _as_is_fields = ['id', 'name', 'code']
 
+    @enforce_string_type
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, self.code)
 
@@ -103,6 +109,7 @@ class Detail(BaseModel):
         ('type', DetailType),
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{} {}: {}>'.format(self.__class__.__name__, self.type.code, self.body[:100])
 
@@ -115,6 +122,7 @@ class ItineraryMedia(Resource):
         'id', 'type', 'video_thumb', 'videos', 'image',
     ]
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.type)
 
@@ -124,6 +132,7 @@ class ItineraryHighlights(Resource):
 
     _as_is_fields = ['id', 'name', 'description', 'media']
 
+    @enforce_string_type
     def __repr__(self):
         return '<{}: {}>'.format(self.__class__.__name__, self.name)
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,9 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
 import datetime
-from unittest import TestCase
+import sys
+from unittest import TestCase, skipIf
 
 from mock import patch
 
@@ -11,6 +15,7 @@ from gapipy.resources import (
     Promotion,
     Tour,
     TourDossier,
+    ActivityDossier,
 )
 from gapipy.resources.base import Resource
 
@@ -130,6 +135,18 @@ class ResourceTestCase(TestCase):
         f = Foo(data, client=self.client)
 
         self.assertEquals(f.bar, None)
+
+    @skipIf(sys.version_info.major > 2, 'Only test for Python 2')
+    def test_repr_returns_bytes_in_python2(self):
+        data = {
+            'id': 123,
+            'name': 'Alc\xe1zar Palace Visit',
+        }
+        ad = ActivityDossier(data, self.client)
+        s = repr(ad)
+        self.assertIsInstance(s, str)
+        self.assertNotIsInstance(s, unicode)
+        self.assertEqual(s, b'<ActivityDossier Alcázar Palace Visit>')
 
 
 class AccommodationRoomTestCase(TestCase):


### PR DESCRIPTION
In Python 2, the output of `__repr__` must be a byte string, while in Python 3, it must be unicode. Since the string representation of many G API resources contain words in non-English languages, they can contain characters outside of the ASCII range, which raises a UnicodeEncodeError when it is implictly coerced to the default encoding by Python.

The way we ensure the return of a proper string type in Python 2 is by encoding the output to UTF-8. This might not be adequate in all use cases of gapipy, but this is what Django does in its codebase, and this seems like a good default.

@bartek I'm still not 100% sure if this is a good idea, but this fixes some actual bugs (I have included some regression tests).