### PR TITLE
Add audience field to Document resource and remove from Invoice

### DIFF
--- a/gapipy/resources/booking/document.py
+++ b/gapipy/resources/booking/document.py
@@ -7,7 +7,7 @@ class Document(Resource):
     _resource_name = 'documents'
     _is_listable = False
 
-    _as_is_fields = ['id', 'href', 'mime_type', 'content', 'type']
+    _as_is_fields = ['id', 'href', 'mime_type', 'content', 'type', 'audience']
     _date_time_fields_utc = ['date_created']
     _resource_fields = [
         ('booking', 'Booking'),
@@ -18,7 +18,7 @@ class Invoice(Resource):
     _resource_name = 'invoices'
     _is_listable = False
 
-    _as_is_fields = ['id', 'href', 'audience']
+    _as_is_fields = ['id', 'href']
     _date_time_fields_utc = ['date_created']
     _resource_fields = [
         ('document', Document),


### PR DESCRIPTION
API currently has the audience field on the Document resource and not in the Invoice resource (seen in the developer playground)