### PR TITLE
Add `__hash__` method to `Resource`

### DIFF
--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -55,6 +55,9 @@ class Resource(BaseModel):
         else:
             return '<{}: {}>'.format(self.__class__.__name__, self.id)
 
+    def __hash__(self):
+        return hash(self.__repr__())
+
     def __eq__(self, other):
         # Same resource name and ID determine equality
         return (


### PR DESCRIPTION
Problem was, couldn't get rid of duplicate resource objects in a list using `set`

https://trello.com/c/L6cUSeED