### PR TITLE
Fix ActivityDossier's Duration initialization

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,12 @@
 History
 =======
 
+2.4.6 (2016-10-????)
+------------------
+
+* Fix broken ``Duration`` init in ``ActivityDossier`` (likely broke due to
+  changes that happened in 2.0.0)
+
 2.4.5 (2016-10-13)
 ------------------
 

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '2.4.5'
+__version__ = '2.4.6'
 __title__ = 'gapipy'
 
 

--- a/gapipy/resources/dossier/activity_dossier.py
+++ b/gapipy/resources/dossier/activity_dossier.py
@@ -51,9 +51,11 @@ class ActivityDossier(Resource, DossierDetailsMixin, DurationLabelMixin, Locatio
             return None
 
         from gapipy.resources import Duration
-        duration = Duration(data=dict(
-            min_hr=self.duration_min,
-            max_hr=self.duration_max)
+        duration = Duration(
+            data=dict(
+                min_hr=self.duration_min,
+                max_hr=self.duration_max),
+            client=self._client,
         )
         return duration
 


### PR DESCRIPTION
**NB: There are probably other things that went into `master` since 2.4.5 besides this bug fix, I just like to add things to HISTORY as they happen. Also, I don't know when this will be release so I've not filled in a date for 2.4.6**

Someone pointed out that the optional activities on gadventures.com are no longer displaying a duration. Seems that the `duration_label` property of an `ActivityDossier` stopped working -- likely due to the 2.0.0 refactor.