### PR TITLE
When fetching a resource, map a 403 error to None...

### DIFF
--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -2,8 +2,16 @@ from functools import wraps
 from itertools import islice
 
 from requests import HTTPError
+from requests.status_codes import codes
 
 from .request import APIRequestor
+
+
+HTTPERRORS_MAPPED_TO_NONE = (
+    codes.FORBIDDEN,  # 403
+    codes.NOT_FOUND,  # 404
+    codes.GONE,  # 410
+)
 
 
 def _check_listable(func):
@@ -55,7 +63,7 @@ class Query(object):
                 cached=cached
             )
         except HTTPError as e:
-            if e.response.status_code in (404, 410):
+            if e.response.status_code in HTTPERRORS_MAPPED_TO_NONE:
                 return None
             raise e
         resource_object = self.resource(data, client=self._client)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -113,6 +113,17 @@ class QueryTestCase(unittest.TestCase):
         self.assertIsInstance(t, Tour)
 
     @patch('gapipy.request.APIRequestor._request')
+    def test_get_instance_with_forbidden_id(self, mock_request):
+        response = Response()
+        response.status_code = 403
+        http_error = HTTPError(response=response)
+        mock_request.side_effect = http_error
+
+        query = Query(self.client, Tour)
+        t = query.get(1234)
+        self.assertIsNone(t)
+
+    @patch('gapipy.request.APIRequestor._request')
     def test_get_instance_with_non_existing_id(self, mock_request):
         response = Response()
         response.status_code = 404


### PR DESCRIPTION
... like we already do with 404s and 410s.

Background: we've recently started serving unpublished dossiers to
certain privileged app-keys who have the necessary permissions -- for
keys *without* those permissions we currently return 404s in this
situation.

That's not a great match for HTTP semantics, so our dossiers-backend
will soon switch over to returning a 403 Forbidden instead of pretending
like the requested resource doesn't exist at all.