### PR TITLE
Use deepcopy to avoid references between data and _raw_data

### DIFF
--- a/gapipy/models/base.py
+++ b/gapipy/models/base.py
@@ -1,4 +1,5 @@
 import sys
+from copy import deepcopy
 from decimal import Decimal
 try:
     # Python 2
@@ -41,11 +42,11 @@ class BaseModel(object):
 
     def __init__(self, data, client):
         self._client = client
-        self._raw_data = data
+        self._raw_data = deepcopy(data)
         self._fill_fields(data)
 
     def _fill_fields(self, data):
-        self._raw_data = data
+        self._raw_data = deepcopy(data)
         first = lambda l: [pair[0] for pair in l]
 
         # Initially we populate base fields, as model/resource fields may rely


### PR DESCRIPTION
This PR fixes an issue preventing partial updates on Resources caused by python being clever (good) and sharing object references.

The issue (using code)
---
```python
import gapipy

gapi = gapipy.Client(application_key=key)
customer = gapi.customer.get(1234)
customer.name['common_name'] = 'New Common Name'
customer.save(partial=True) # doesn't update the resource
```

The reason for the lack of update is because the `name` property is a `dict`. The base `to_dict()` method and the originally saved `_raw_data` share a reference to the same underlying `dict`.

When we modify the `common_name`, what's being changed is the same underlying `dict`. Thus, when we try to `save(partial=True)`, the same locally modified values are compared in `_update`, which results in no difference being found, and the `save` is avoided (to save network bandwidth).

The Fix
---
Using `deepcopy` when initializing `_raw_data` property avoids these shared references by allocating an entirely new and separate object distinct from the `properties` accessible/modifiable set on the `Resource` using `_fill_fields`