### PR TITLE
Add tox runner and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,21 @@ tests can successfully hit the API::
 
     $ export GAPI_APPLICATION_KEY=MY_SECRET_KEY; nosetests
 
+In addition to running the test suite against your local Python interpreter, you
+can run tests using `Tox <http://tox.testrun.org>`_. Tox allows the test suite
+to be run against multiple environments, or in this case, multiple versions of
+Python. Install and run the ``tox`` command from any place in the gapipy source
+tree::
+
+  $ pip install tox
+  $ tox
+
+Tox will attempt to run against all environments defined in the ``tox.ini``. It
+is recommended to use a tool like `pyenv <https://github.com/yyuu/pyenv>`_ to
+ensure you have multiple versions of Python available on your machine for Tox to
+use.
+
+
 Fields
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -187,8 +187,9 @@ In addition to running the test suite against your local Python interpreter, you
 can run tests using `Tox <http://tox.testrun.org>`_. Tox allows the test suite
 to be run against multiple environments, or in this case, multiple versions of
 Python. Install and run the ``tox`` command from any place in the gapipy source
-tree::
+tree. You'll want to export your G API application key as well::
 
+  $ export GAPI_APPLICATION_KEY=MY_SECRET_KEY
   $ pip install tox
   $ tox
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
     test_suite='nose.collector',
     tests_require=test_requirements,

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27,py35,py36
+skip_missing_interpreters = True
+
+[testenv]
+commands =
+    pip install -r requirements-testing.txt
+    python setup.py test
+passenv = GAPI_APPLICATION_KEY


### PR DESCRIPTION
Now that we are a real library which supports Python 3.x, we should
include tox as part of the repository. This initial tox.ini file tests
that gapipy is passing tests on Python 2.7, 3.5, and 3.6

README has been amended to include details on how to run tox