### PR TITLE
Add `future` to requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ history = open('HISTORY.rst').read().replace('.. :changelog:', '')
 
 requirements = [
     'requests',
+    'future',
 ]
 
 test_requirements = [


### PR DESCRIPTION
When pip installing gapipy it fails due to a missing import.

```
  File "/opt/lib/virtualenvs/lumos/local/lib/python2.7/site-packages/gapipy/resources/booking/service.py", line 4, in <module>
    from future.utils import with_metaclass
ImportError: No module named future.utils
```

It might make more sense to not have a requirements.txt file and just use this setup.py file so we don't have to maintain two lists of requirements.