### PR TITLE
Do not recache on `get`

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,14 @@
 History
 =======
 
+Unreleased
+----------
+
+* Fixed `issue 65 <https://github.com/gadventures/gapipy/issues/65>`_: only
+  write data into the local cache after a fetch from the API, do not write data
+  into the local cache when fetching from the local cache.
+
+
 2.5.2 (2017-04-26)
 ------------------
 

--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -67,7 +67,6 @@ class Query(object):
                 return None
             raise e
         resource_object = self.resource(data, client=self._client)
-        self._client._cache.set(key, resource_object.to_dict())
         return resource_object
 
     def get_resource_data(self, resource_id, variation_id=None, cached=True):
@@ -82,9 +81,11 @@ class Query(object):
             if resource_data is not None:
                 return resource_data
 
-        # Cache miss; get fresh data from the backend.
+        # Cache miss; get fresh data from the backend, set in cache
         requestor = APIRequestor(self._client, self.resource)
         out = requestor.get(resource_id, variation_id=variation_id)
+        if out is not None:
+            self._client._cache.set(key, out)
         self._filters = {}
         return out
 


### PR DESCRIPTION
Adds a regression test and a fix for issue #65.

If you check out 6b45f0a the regression test will fail; 2459788 has the fix, check that out and the test will pass.

NB: I added a note about this in `HISTORY.rst`, but haven't added a version number or release date... needs to be updated when a release happens