### PR TITLE
Add document type to agency_document

### DIFF
--- a/gapipy/models/agency_document.py
+++ b/gapipy/models/agency_document.py
@@ -2,4 +2,4 @@ from .base import BaseModel
 
 class AgencyDocument(BaseModel):
     " Represents a document for an agency. "
-    _as_is_fields = ['file']
+    _as_is_fields = ['file', 'type']


### PR DESCRIPTION
We need to retrieve the logo in operator and this field is the only
consistent one identifying this.