### PR TITLE
Fix failing DepartureAddonTestCase tests

### DIFF
--- a/gapipy/models/addon.py
+++ b/gapipy/models/addon.py
@@ -5,7 +5,10 @@ from ..utils import enforce_string_type
 class AddOn(BaseModel, RelatedResourceMixin):
     _as_is_fields = ['max_days', 'min_days', 'product']
     _date_fields = ['start_date', 'finish_date', 'halt_booking_date', 'request_space_date']
-    _resource_fields = []
+
+    def __init__(self, *args, **kwargs):
+        self._resource_fields = []
+        super(AddOn, self).__init__(*args, **kwargs)
 
     @enforce_string_type
     def __repr__(self):


### PR DESCRIPTION
Just a fix for the regression test introduced in #71 ...

Unfortunately 29f4217610b048b9385cca1d8b980dc55953371e broke the tests on `master` (`test_listing_non_listable_resource_fails` fails because `accommodations` just became listable for sandbox) so the tests on this PR also fail.

If you look at the details of the #71 test run, though, you can see the `DepartureAddonTestCase` test fail. If you check the test run for this PR you can see the  `DepartureAddonTestCase` test is no longer failing.