### PR TITLE
Reset Query._filters when calling .all()

### DIFF
--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -130,6 +130,7 @@ class Query(object):
             parent=self.parent
         )
         generator = requestor.list()
+        self._filters = {}
 
         if limit:
             if isinstance(limit, int) and limit > 0:


### PR DESCRIPTION
See issue #76

Prior to this commit, multiple calls to `.filter()` accumulate arguments over time into a dict at `Query._filter`. When "evaluating" those stored filters by calling `.count()` gapipy resets the dict at `Query._filter`. When "evaluating" those stored filters by calling `.all()` gapipy does not reset the cached filter arguments.

Basically what this amounted to was that if I wanted to write some code that does two *unrelated* filtering queries on the same resource I would have to something like one of the following:
- instantiate two separate gapipy clients, one for each query
- do a (meaningless) `.count()` after my first query in order to flush out the old filter arguments
- reach into my gapipy client and modify the `_filter` dict

This commit changes the behaviour of gapipy such that calling `.all()` resets the stored filter arguments