### PR TITLE
Update Agent resource representation

### DIFF
--- a/gapipy/resources/booking/agent.py
+++ b/gapipy/resources/booking/agent.py
@@ -1,8 +1,16 @@
 from __future__ import unicode_literals
 
-from ..base import Resource
+from ..base import BaseModel, Resource
 
 from .agency import Agency
+
+
+class AgentRole(BaseModel):
+    _as_is_fields = ['id', 'name']
+
+
+class AgentPhoneNumber(BaseModel):
+    _as_is_fields = ['number', 'type']
 
 
 class Agent(Resource):
@@ -10,7 +18,18 @@ class Agent(Resource):
     _is_listable = False
 
     _as_is_fields = [
-        'id', 'href', 'role', 'first_name', 'last_name', 'email',
-        'phone_numbers', 'username', 'active',
+        'id',
+        'href',
+        'first_name',
+        'last_name',
+        'email',
+        'username',
+        'active',
+    ]
+    _model_fields = [
+        ('role', AgentRole),
+    ]
+    _model_collection_fields = [
+        ('phone_numbers', AgentPhoneNumber),
     ]
     _resource_fields = [('agency', Agency)]


### PR DESCRIPTION
Use the `BaseModel` class to represent the `role` & `phone_numbers` fields. This will enable attribute access semantics for these fields. Before and after usage is as follows:

```python
agent = client.agent.get(1234)

# current
agent.role['id']
agent.phone_numbers[0]['number']

# after PR
agent.role.id
agent.phone_numbers[0].number
```