### PR TITLE
BugFix: `PricePromotion` fields

### DIFF
--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -14,16 +14,28 @@ class PricePromotion(Resource):
 
         klass = get_resource_class_from_resource_name('promotions')
 
+        promotion_field_types = [
+            '_as_is_fields',
+            '_date_time_fields_utc',
+            '_date_fields',
+            '_price_fields',
+            '_model_collection_fields',
+            '_resource_collection_fields',
+        ]
+
         # Python 2 and 3
         # inefficient on Python 2 to list items()
-        for k, v in list(klass.__dict__.items()):
-            if 'fields' in k:
-                setattr(self, k, v)
-            if '_is_parent_resource' in k:
-                setattr(self, k, v)
+        for field_type in promotion_field_types:
+            value = getattr(klass, field_type, None)
+            if value:
+                setattr(self, field_type, value)
+
+        if getattr(klass, '_is_parent_resource', None):
+            setattr(self, klass._is_parent_resource)
 
         super(PricePromotion, self).__init__(data, **kwargs)
 
         # Add the "fake" amount field.
-        self._price_fields.append('amount')
-        setattr(self, 'amount', data['amount'])
+        if 'amount' not in self._price_fields:
+            self._price_fields.append('amount')
+            setattr(self, 'amount', data['amount'])

--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -13,11 +13,14 @@ class PricePromotion(Resource):
         self._resource_name = 'promotions'
 
         klass = get_resource_class_from_resource_name('promotions')
+
         # Python 2 and 3
         # inefficient on Python 2 to list items()
         for k, v in list(klass.__dict__.items()):
             if 'fields' in k and isinstance(v, list):
                 setattr(self, k, getattr(klass, k))
+            if '_is_parent_resource' in k:
+                setattr(self, k, v)
 
         super(PricePromotion, self).__init__(data, **kwargs)
 

--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -18,7 +18,7 @@ class PricePromotion(Resource):
         # inefficient on Python 2 to list items()
         for k, v in list(klass.__dict__.items()):
             if 'fields' in k:
-                setattr(self, k, getattr(klass, k))
+                setattr(self, k, v)
             if '_is_parent_resource' in k:
                 setattr(self, k, v)
 

--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -20,6 +20,7 @@ class PricePromotion(Resource):
             '_date_fields',
             '_price_fields',
             '_model_collection_fields',
+            '_resource_collection_fields',
         ]
 
         # Python 2 and 3

--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -31,7 +31,7 @@ class PricePromotion(Resource):
                 setattr(self, field_type, value)
 
         if getattr(klass, '_is_parent_resource', None):
-            setattr(self, klass._is_parent_resource)
+            setattr(self, '_is_parent_resource', klass._is_parent_resource)
 
         super(PricePromotion, self).__init__(data, **kwargs)
 

--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -17,7 +17,7 @@ class PricePromotion(Resource):
         # Python 2 and 3
         # inefficient on Python 2 to list items()
         for k, v in list(klass.__dict__.items()):
-            if 'fields' in k and isinstance(v, list):
+            if 'fields' in k:
                 setattr(self, k, getattr(klass, k))
             if '_is_parent_resource' in k:
                 setattr(self, k, v)

--- a/gapipy/models/price_promotion.py
+++ b/gapipy/models/price_promotion.py
@@ -20,7 +20,6 @@ class PricePromotion(Resource):
             '_date_fields',
             '_price_fields',
             '_model_collection_fields',
-            '_resource_collection_fields',
         ]
 
         # Python 2 and 3


### PR DESCRIPTION
A get on:
```
departure.rooms[0].price_bands[0].prices[0].promotions[0]
```
Would throw:
```
*** AttributeError: 'PricePromotion' has no field 'id' available
```

This is because the fields were not properly copied to `PricePromotion`

Trello: https://trello.com/c/qvLlZZHX/1336-gapipy-promotions-bug