### PR TITLE
Customers.address should use/return the Address BaseModel

### DIFF
--- a/gapipy/models/address.py
+++ b/gapipy/models/address.py
@@ -1,5 +1,6 @@
+from gapipy.utils import enforce_string_type
+
 from .base import BaseModel
-from ..utils import enforce_string_type
 
 
 class Address(BaseModel):

--- a/gapipy/resources/booking/customer.py
+++ b/gapipy/resources/booking/customer.py
@@ -1,7 +1,9 @@
 # Python 2 and 3
 from __future__ import unicode_literals
 
-from ..base import Resource, BaseModel
+from gapipy.models import Address
+from gapipy.models.base import BaseModel
+from gapipy.resources.base import Resource
 
 
 class MedicalDetail(BaseModel):
@@ -15,7 +17,6 @@ class Customer(Resource):
 
     _as_is_fields = [
         'account_email',
-        'address',
         'emergency_contacts',
         'gender',
         'href',
@@ -31,6 +32,10 @@ class Customer(Resource):
     ]
 
     _date_fields = ['date_of_birth', ]
+
+    _model_fields = [
+        ('address', Address),
+    ]
 
     _model_collection_fields = [
         ('medical_details', MedicalDetail),


### PR DESCRIPTION
This allows `customer.address` fields to be accessible correctly
using the dot (.) attribute syntax, as well as correctly exposing the
State/Country Resources on the `customer.address`

Usage:
```python
from gapipy import Client

client = Client(application_key='your_api_key')

customer = client.customers.get(1234)

# prior to this PR:
customer.address  # returns  a dict
state_id = customer.address['state']['id']
state_name = ... # not possible as the data is not returned / stored as a Model

# after this PR:
customer.address # returns the underlying Address model
state_id = customer.address.state.id
state_name = customer.address.state.name
```

Misc: start removing relative imports