### PR TITLE
Add ability to include uuid as part of each request

### DIFF
--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -23,7 +23,7 @@ default_config = {
         'number': os.environ.get('GAPI_CLIENT_CONNECTION_POOL_NUMBER', 10),
         'maxsize': os.environ.get('GAPI_CLIENT_CONNECTION_POOL_MAXSIZE', 10),
     },
-    'uuid': os.environ.get('GAPI_UUID', ''),
+    'uuid': os.environ.get('GAPI_UUID', False),
 }
 
 

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -23,6 +23,7 @@ default_config = {
         'number': os.environ.get('GAPI_CLIENT_CONNECTION_POOL_NUMBER', 10),
         'maxsize': os.environ.get('GAPI_CLIENT_CONNECTION_POOL_MAXSIZE', 10),
     },
+    'uuid': os.environ.get('GAPI_UUID', ''),
 }
 
 
@@ -48,6 +49,7 @@ class Client(object):
         self.api_proxy = get_config(config, 'api_proxy')
         self.api_language = get_config(config, 'api_language')
         self.cache_backend = get_config(config, 'cache_backend')
+        self.uuid = get_config(config, 'uuid')
 
         # begin with default connection pool options and overwrite any that the
         # client has specified

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -15,18 +15,20 @@ JSON_CONTENT_TYPE = 'application/json'
 
 class APIRequestor(object):
 
-    def __init__(self, client, resource, params=None, parent=None):
+    def __init__(self, client, resource, params={}, parent=None):
         self.client = client
         self.resource = resource
         self.params = params
         self.parent = parent
 
-    def _request(self, uri, method, data=None, params=None, additional_headers=None):
+    def _request(self, uri, method, data=None, params={}, additional_headers=None):
         """Make an HTTP request to a target API method with proper headers."""
 
         assert method in ALLOWED_METHODS, "Only {} are allowed.".format(', '.join(ALLOWED_METHODS))
         url = self._get_url(uri)
         headers = self._get_headers(method, additional_headers)
+        if self.client.uuid:
+            params['uuid'] = self.client.uuid
         response = self._make_call(method, url, headers, data, params)
         return response
 

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -1,5 +1,6 @@
 import requests
 import sys
+from uuid import uuid1
 
 from . import __title__, __version__
 
@@ -15,20 +16,22 @@ JSON_CONTENT_TYPE = 'application/json'
 
 class APIRequestor(object):
 
-    def __init__(self, client, resource, params={}, parent=None):
+    def __init__(self, client, resource, params=None, parent=None):
         self.client = client
         self.resource = resource
         self.params = params
         self.parent = parent
 
-    def _request(self, uri, method, data=None, params={}, additional_headers=None):
+    def _request(self, uri, method, data=None, params=None, additional_headers=None):
         """Make an HTTP request to a target API method with proper headers."""
 
         assert method in ALLOWED_METHODS, "Only {} are allowed.".format(', '.join(ALLOWED_METHODS))
         url = self._get_url(uri)
         headers = self._get_headers(method, additional_headers)
         if self.client.uuid:
-            params['uuid'] = self.client.uuid
+            if not params:
+                params = {}
+            params['uuid'] = str(uuid1())
         response = self._make_call(method, url, headers, data, params)
         return response
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -14,18 +14,19 @@ class Resources(object):
         self.__dict__.update(kwArgs)
 
 
-@patch('gapipy.request.APIRequestor._request')
 class APIRequestorTestCase(unittest.TestCase):
 
     def setUp(self):
         self.client = Client()
         self.resources = Resources(_resource_name='resources', _uri=None)
 
+    @patch('gapipy.request.APIRequestor._request')
     def test_get_resource_by_id(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.get(1234)
         mock_request.assert_called_once_with('/resources/1234', 'GET')
 
+    @patch('gapipy.request.APIRequestor._request')
     def test_get_with_null_resource_id_and_uri_raises_error(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         error_msg = 'Need to provide at least one of `resource_id` or `uri` as argument'
@@ -36,25 +37,28 @@ class APIRequestorTestCase(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, error_msg):
                 requestor.get()
 
+    @patch('gapipy.request.APIRequestor._request')
     def test_get_with_falsy_resource_id_does_not_raise_error(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.get(0)
         mock_request.assert_called_once_with('/resources/0', 'GET')
 
+    @patch('gapipy.request.APIRequestor._request')
     def test_list_resource(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.list_raw()
-        mock_request.assert_called_once_with('/resources', 'GET', params=None)
+        mock_request.assert_called_once_with('/resources', 'GET', params={})
 
+    @patch('gapipy.request.APIRequestor._request')
     def test_list_resource_with_parent(self, mock_request):
         parent = ('parent', '1234', None)
         requestor = APIRequestor(self.client, self.resources, parent=parent)
         requestor.list_raw()
         mock_request.assert_called_once_with(
-            '/parent/1234/resources', 'GET', params=None)
+            '/parent/1234/resources', 'GET', params={})
 
     @patch('gapipy.request.APIRequestor.list_raw')
-    def test_list_generator(self, mock_list, mock_request):
+    def test_list_generator(self, mock_list):
         mock_list.side_effect = [FIRST_PAGE_LIST_DATA, SECOND_PAGE_LIST_DATA]
         expected_calls = [
             call(None),
@@ -66,3 +70,29 @@ class APIRequestorTestCase(unittest.TestCase):
 
         self.assertEqual(mock_list.mock_calls, expected_calls)
         self.assertEqual(len(resources), 6)
+
+    @patch('gapipy.request.APIRequestor._request')
+    def test_uuid_not_set(self, mock_request):
+        self.client.uuid = ''
+        requestor = APIRequestor(self.client, self.resources)
+        requestor.params = {'test': '1234'}
+        requestor.list_raw()
+        mock_request.assert_called_once_with('/resources', 'GET', params={'test': '1234'})
+
+    @patch('gapipy.request.APIRequestor._make_call')
+    def test_uuid_set(self, mock_make_call):
+        self.client.uuid = 'test-case'
+        requestor = APIRequestor(self.client, self.resources)
+        # requestor.params = {'test': '1234'}
+        requestor.list_raw()
+        params_arg = mock_make_call.call_args[0][-1]
+        self.assertEqual(params_arg, {'uuid': 'test-case'})
+
+    @patch('gapipy.request.APIRequestor._make_call')
+    def test_uuid_with_other_params(self, mock_make_call):
+        self.client.uuid = 'test-case'
+        requestor = APIRequestor(self.client, self.resources)
+        requestor.params = {'test': '1234'}
+        requestor.list_raw()
+        params_arg = mock_make_call.call_args[0][-1]
+        self.assertEqual(params_arg, {'test': '1234', 'uuid': 'test-case'})

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -47,7 +47,7 @@ class APIRequestorTestCase(unittest.TestCase):
     def test_list_resource(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.list_raw()
-        mock_request.assert_called_once_with('/resources', 'GET', params={})
+        mock_request.assert_called_once_with('/resources', 'GET', params=None)
 
     @patch('gapipy.request.APIRequestor._request')
     def test_list_resource_with_parent(self, mock_request):
@@ -55,7 +55,7 @@ class APIRequestorTestCase(unittest.TestCase):
         requestor = APIRequestor(self.client, self.resources, parent=parent)
         requestor.list_raw()
         mock_request.assert_called_once_with(
-            '/parent/1234/resources', 'GET', params={})
+            '/parent/1234/resources', 'GET', params=None)
 
     @patch('gapipy.request.APIRequestor.list_raw')
     def test_list_generator(self, mock_list):
@@ -73,7 +73,7 @@ class APIRequestorTestCase(unittest.TestCase):
 
     @patch('gapipy.request.APIRequestor._request')
     def test_uuid_not_set(self, mock_request):
-        self.client.uuid = ''
+        self.client.uuid = False
         requestor = APIRequestor(self.client, self.resources)
         requestor.params = {'test': '1234'}
         requestor.list_raw()
@@ -81,18 +81,18 @@ class APIRequestorTestCase(unittest.TestCase):
 
     @patch('gapipy.request.APIRequestor._make_call')
     def test_uuid_set(self, mock_make_call):
-        self.client.uuid = 'test-case'
+        self.client.uuid = True
         requestor = APIRequestor(self.client, self.resources)
-        # requestor.params = {'test': '1234'}
         requestor.list_raw()
         params_arg = mock_make_call.call_args[0][-1]
-        self.assertEqual(params_arg, {'uuid': 'test-case'})
+        self.assertTrue('uuid' in params_arg)
 
     @patch('gapipy.request.APIRequestor._make_call')
     def test_uuid_with_other_params(self, mock_make_call):
-        self.client.uuid = 'test-case'
+        self.client.uuid = True
         requestor = APIRequestor(self.client, self.resources)
         requestor.params = {'test': '1234'}
         requestor.list_raw()
         params_arg = mock_make_call.call_args[0][-1]
-        self.assertEqual(params_arg, {'test': '1234', 'uuid': 'test-case'})
+        self.assertEqual(params_arg['test'], '1234')
+        self.assertTrue('uuid' in params_arg)


### PR DESCRIPTION
Included a config option GAPI_UUID that sets the uuid param on every request made to the API