### PR TITLE
Add option to include headers in 'GET' requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,8 +82,9 @@ only supported for queries whose resources are listable.
 ``options()``
     Get the options for a single resource
 
-``get(resource_id)``
-    Get a single resource.
+``get(resource_id, [headers={}])``
+    Get a single resource; optionally passing in a dictionary of header
+    values.
 
 ``create(data)``
     Create an instance of the query resource using the given data.

--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -45,7 +45,7 @@ class Query(object):
     def options(self):
         return self.resource.options(client=self._client)
 
-    def get(self, resource_id, variation_id=None, cached=True):
+    def get(self, resource_id, variation_id=None, cached=True, headers=None):
         """
         Returns an instance of the query resource with the given `resource_id`
         (and optional `variation_id`) or `None` if the resource with the given
@@ -63,7 +63,8 @@ class Query(object):
             data = self.get_resource_data(
                 resource_id,
                 variation_id=variation_id,
-                cached=cached
+                cached=cached,
+                headers=headers
             )
         except HTTPError as e:
             if e.response.status_code in HTTPERRORS_MAPPED_TO_NONE:
@@ -72,7 +73,7 @@ class Query(object):
         resource_object = self.resource(data, client=self._client)
         return resource_object
 
-    def get_resource_data(self, resource_id, variation_id=None, cached=True):
+    def get_resource_data(self, resource_id, variation_id=None, cached=True, headers=None):
         '''
         Returns a dictionary of resource data, which is used to initialize
         a Resource object in the `get` method.
@@ -86,7 +87,7 @@ class Query(object):
 
         # Cache miss; get fresh data from the backend, set in cache
         requestor = APIRequestor(self._client, self.resource)
-        out = requestor.get(resource_id, variation_id=variation_id)
+        out = requestor.get(resource_id, variation_id=variation_id, headers=headers)
         if out is not None:
             self._client._cache.set(key, out)
         self._filters = {}

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -112,7 +112,7 @@ class APIRequestor(object):
         """
         return self._request('/{0}'.format(self._get_uri()), 'OPTIONS')
 
-    def get(self, resource_id=None, uri=None, variation_id=None):
+    def get(self, resource_id=None, uri=None, variation_id=None, headers=None):
         """
         Get a single resource with the given resource_id or uri
 
@@ -128,7 +128,7 @@ class APIRequestor(object):
         if variation_id:
             components.append(str(variation_id))
         uri = '/'.join(components)
-        return self._request(uri, 'GET')
+        return self._request(uri, 'GET', additional_headers=headers)
 
     def update(self, resource_id, data, partial=True, uri=None):
         """


### PR DESCRIPTION
This helps with debugging through the various G-API caches. @marz619 and I were debugging the cache and being able to throw the `headers={'Some-Header': 'header-value'}` could be helpful in future.

i.e. `gapi.bookings.get(<booking_id>, cached=False, headers={'Some-Header': 'header-value'})`