### PR TITLE
Remove add_ons from Departure

### DIFF
--- a/gapipy/resources/tour/departure.py
+++ b/gapipy/resources/tour/departure.py
@@ -60,5 +60,3 @@ class Departure(Product):
         ('rooms', DepartureRoom),
         ('structured_itineraries', 'Itinerary'),
     ]
-    # mark deprecated fields
-    _deprecated_fields = ['add_ons']


### PR DESCRIPTION
Remove the deprecated `add_ons` field from the `departure` resource.

The field is no longer served via the API, and was removed in May, 2018.