### PR TITLE
Expose Linked Bookings via the API

### DIFF
--- a/gapipy/resources/booking/booking.py
+++ b/gapipy/resources/booking/booking.py
@@ -46,3 +46,9 @@ class Booking(Resource):
             ('overrides', Override),
             ('checkins', Checkin),
         ]
+
+    @property
+    def _model_collection_fields(self):
+        return [
+            ('linked_bookings', Booking),
+        ]


### PR DESCRIPTION
This will expose all bookings linked to this one booking in the payload for the API.