### PR TITLE
Split integration tests in Travis into separate jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install redis
 
 # command to run tests
-script: python setup.py nosetests -A integration!=$INTEGRATION
+script: python setup.py nosetests -A integration=$INTEGRATION
 
 services:
   - redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ install:
   - pip install redis
 
 # command to run tests
-script: python setup.py nosetests -A integration=$INTEGRATION
+script: python setup.py nosetests -A integration==$INTEGRATION
 
 services:
   - redis

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,17 @@ python:
 
 sudo: false
 
+env:
+  - INTEGRATION=1
+  - INTEGRATION=0
+
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install -r requirements-testing.txt
   - pip install redis
 
-# command to run tests, e.g. python setup.py test
-script: python setup.py test
+# command to run tests
+script: python setup.py nosetests -A integration!=$INTEGRATION
 
 services:
   - redis


### PR DESCRIPTION
Not so much trying to speed things up as to provide better visibility into failures at a glance.

Note that this changes the `script` that Travis will run from `setup.py test` to `setup.py nosetests` ... not sure if there was an explicit desire to AVOID using nose in this context, but I WANT to use nose in order to use the same `-A integration!=X` flag that is illustrated in [the gapipy README](https://github.com/gadventures/gapipy#testing)