### PR TITLE
Remove `sudo: false` from .travis.yml...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ python:
   - "2.7"
   - "3.6"
 
-sudo: false
-
 env:
   - INTEGRATION=1
   - INTEGRATION=0


### PR DESCRIPTION
... because Travis says that that feature is going away:
    https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration