### PR TITLE
RedisCache.set fix (setex argument order changed between redis 2.x & 3.x)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,20 @@
 
 language: python
 
-python:
-  - "2.7"
-  - "3.6"
-
 matrix:
   include:
-    - env: INTEGRATION=0 REDIS="redis==2.10.6"
-    - env: INTEGRATION=0 REDIS="redis==3.1.0"
-    - env: INTEGRATION=1 REDIS="redis"
+    - python: 2.7
+      env: INTEGRATION=0 REDIS="redis==2.10.6"
+    - python: 2.7
+      env: INTEGRATION=0 REDIS="redis==3.1.0"
+    - python: 2.7
+      env: INTEGRATION=1 REDIS="redis"
+    - python: 3.6
+      env: INTEGRATION=0 REDIS="redis==2.10.6"
+    - python: 3.6
+      env: INTEGRATION=0 REDIS="redis==3.1.0"
+    - python: 3.6
+      env: INTEGRATION=1 REDIS="redis"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,16 @@ python:
   - "2.7"
   - "3.6"
 
-env:
-  - INTEGRATION=1
-  - INTEGRATION=0
-  - REDIS_VERSION=2.10.6
-  - REDIS_VERSION=3.1.0
+matrix:
+  include:
+    - env: INTEGRATION=0 REDIS="redis==2.10.6"
+    - env: INTEGRATION=0 REDIS="redis==3.1.0"
+    - env: INTEGRATION=1 REDIS="redis"
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install -q -r requirements-testing.txt
-  - pip install -q redis==$REDIS_VERSION
+  - pip install -q $REDIS
 
 # command to run tests
 script: python setup.py nosetests -A integration==$INTEGRATION

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,11 +9,13 @@ python:
 env:
   - INTEGRATION=1
   - INTEGRATION=0
+  - REDIS_VERSION=2.10.6
+  - REDIS_VERSION=3.1.0
 
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install -r requirements-testing.txt
-  - pip install redis
+  - pip install -q -r requirements-testing.txt
+  - pip install -q redis==$REDIS_VERSION
 
 # command to run tests
 script: python setup.py nosetests -A integration==$INTEGRATION

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,18 @@
 History
 =======
 
+2.19.2 (2019-02-12)
+-------------------
+
+* Become agnostic between redis 2.x.x && 3.x.x versions
+
+  * ``setex`` method argument order changes between the major versions
+
+
 2.19.1 (2019-02-12)
 -------------------
 
-* Fix for ``2.19.0`` -- adds ``requirements.txt`` file to the distribution ``MANIFEST``
+* HotFix for ``2.19.0`` -- adds ``requirements.txt`` file to the distribution ``MANIFEST``
 
 
 2.19.0 (2019-02-12)

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '2.19.1'
+__version__ = '2.19.2'
 __title__ = 'gapipy'
 
 


### PR DESCRIPTION
Tests python-redis 2.x & 3.x versions due to `setex` argument order changes between the major versions. We detect the `redis` version on `RedisCache` initialization and store it onto the class, and use that to call the `setex` method with the correct argument order.

* the order of arguments for ``setex`` has changed between 2.x.x & 3.x.x
  * redis `2.x.x` setex argument order: `name/key`, `value`, `time/out`
  * redis `3.x.x` setex argument order: `name/key`, `time/out`, `value`

* an alternative option would be to use StrictRedis client but this
change _should_ hold us over for now