### PR TITLE
Add `get_category` helper method to Tour Dossier resource

### DIFF
--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -90,3 +90,8 @@ class TourDossier(Resource):
         for detail in self.details:
             if detail['detail_type']['label'] == label:
                 return detail['body']
+
+    def get_category_name(self, label):
+        for category in self.categories:
+            if category['category_type']['label'] == label:
+                return category['name']

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -65,7 +65,7 @@ class TourDossierTestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.dossier = Client().tour_dossiers.get(21715)
+        cls.dossier = Client().tour_dossiers.get(24515)
 
     def setUp(self):
         self.dossier = TourDossierTestCase.dossier
@@ -89,13 +89,22 @@ class TourDossierTestCase(TestCase):
         self.assertIsInstance(countries, list)
 
     def test_get_trip_detail(self):
-        detail = self.dossier.get_trip_detail('Max Pax')
+        detail = self.dossier.get_trip_detail('Highlights')
         if sys.version_info.major < 3:
             # Python 2
             self.assertIsInstance(detail, basestring)
         else:
             # Python 3
             self.assertIsInstance(detail, str)
+
+    def test_get_category_name(self):
+        category = self.dossier.get_category_name('Trip Type')
+        if sys.version_info.major < 3:
+            # Python 2
+            self.assertIsInstance(category, basestring)
+        else:
+            # Python 3
+            self.assertIsInstance(category, str)
 
 
 @attr('integration')
@@ -131,7 +140,7 @@ class LiveAPITestCase(TestCase):
         (Timezone, 4),
         (Tour, 21715),
         (TourCategory, 15),
-        (TourDossier, 21715),
+        (TourDossier, 24515),
         (Transport, 298),
         (TransportDossier, 51),
     ]


### PR DESCRIPTION
This is analogous to the existing `get_trip_detail` method.

The integration tests have been adjusted to use a Tour Dossier instance that does have `categories` defined for it.