### PR TITLE
Remove deprecated `tour_dossiers.itineraries` field

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,8 @@
 History
 =======
 
-UNRELEASED
-----------
+2.23.0 (2019-11-04)
+-------------------
 
 * Remove deprecated ``tour_dossiers.itineraries`` field and related code
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,11 +3,15 @@
 History
 =======
 
+UNRELEASED
+----------
+
+* Remove deprecated ``tour_dossiers.itineraries`` field and related code
+
 2.22.0 (2019-10-10)
 -------------------
 
 * Add ``booking_company`` field to ``Booking`` resource
-
 
 2.21.0 (2019-04-09)
 -------------------

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '2.22.0'
+__version__ = '2.23.0'
 __title__ = 'gapipy'
-
 
 from .client import Client  # NOQA

--- a/gapipy/resources/tour/tour.py
+++ b/gapipy/resources/tour/tour.py
@@ -25,12 +25,6 @@ class Tour(Resource):
         """, DeprecationWarning)
         super(Tour, self).__init__(*args, **kwargs)
 
-    def get_brief_itinerary(self):
-        return self.tour_dossier.get_brief_itinerary()
-
-    def get_detailed_itinerary(self):
-        return self.tour_dossier.get_detailed_itinerary()
-
     def get_map_url(self):
         return self.tour_dossier.get_map_url()
 

--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -8,8 +8,6 @@ from gapipy.resources.booking_company import BookingCompany
 from gapipy.utils import get_resource_class_from_class_name
 
 
-BRIEF_ITINERARY_TYPE = 'SUMMARY'
-DETAILED_ITINERARY_TYPE = 'DETAILED'
 MAP_IMAGE_TYPE = 'MAP'
 BANNER_IMAGE_TYPE = 'BANNER'
 
@@ -27,7 +25,6 @@ class TourDossier(Resource):
         'product_line',
         'geography',
         'images',
-        'itineraries',
         'name',
         'site_links',
     ]
@@ -60,17 +57,6 @@ class TourDossier(Resource):
             setattr(self, field, query)
         else:
             return super(TourDossier, self)._set_resource_collection_field(field, value)
-
-    def _get_itinerary(self, itinerary_type):
-        for itin in self.itineraries:
-            if itin['type'] == itinerary_type:
-                return [dict(label=i['label'], body=i['body']) for i in itin['days']]
-
-    def get_brief_itinerary(self):
-        return self._get_itinerary(BRIEF_ITINERARY_TYPE)
-
-    def get_detailed_itinerary(self):
-        return self._get_itinerary(DETAILED_ITINERARY_TYPE)
 
     def _get_image_url(self, image_type):
         for image in self.images:

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -93,54 +93,6 @@ SECOND_PAGE_LIST_DATA = {
 PPP_DOSSIER_DATA = {
     "departures_start_date": "2013-01-01",
     "departures_end_date": "2013-12-31",
-    "itineraries": [
-        {
-            "duration": 15,
-            "type": "SUMMARY",
-            "days": [
-                {
-                    "body": "Arrive at any time.",
-                    "id": "125737468",
-                    "label": "Day 1 Lima"
-                },
-                {
-                    "body": "Fly to Juliaca and transfer to Puno.  Visit the floating Islands of Uros and take a guided tour of Lake Titicaca with a homestay in a small village.   Optional visit to Sillustani burial site.",
-                    "id": "125737469",
-                    "label": "Days 2-4 Puno/Lake Titicaca (1B,1L,1D)"
-                },
-                {
-                    "body": "Travel day by bus from Puno to Cuzco.",
-                    "id": "125737470",
-                    "label": "Day 5 Cuzco"
-                },
-                {
-                    "body": "Full day guided tour of the Sacred Valley and Ollantaytambo ruins along with a visit to a Planeterra weaving project in a local community. Shopping opportunities at a local market.",
-                    "id": "125737471",
-                    "label": "Day 6 Sacred Valley/Ollantaytambo"
-                },
-                {
-                    "body": "4-day guided Inca Trail hike with visit to Machu Picchu. Optional visit to the Inca Bridge before returning to Cuzco.",
-                    "id": "125737472",
-                    "label": "Days 7-10 Inca Trail/Machu Picchu (3B,3L,3D)"
-                },
-                {
-                    "body": "Free day to explore Cuzco or relax. Active options include whitewater rafting, horseback riding and mountain biking.",
-                    "id": "125737473",
-                    "label": "Day 11 Cuzco"
-                },
-                {
-                    "body": "Fly to Puerto Maldonado and continue by motorized canoe to our comfortable, intimate and exclusive G Lodge Amazon. Enjoy guided excursions by expert naturalists to spot wildlife at nearby oxbow lakes, clay licks and treetop towers. Included rubber boots while at the lodge. Fly back to Lima on Day 14.",
-                    "id": "125737474",
-                    "label": "Days 12-14 Amazon Jungle (2B,2L,2D)"
-                },
-                {
-                    "body": "Depart at any time.",
-                    "id": "125737475",
-                    "label": "Day 15 Lima"
-                }
-            ]
-        }
-    ],
     "description": "Spot macaws in the jungle and caimans on the riverbanks, sail the waters of Lake Titicaca, delight in the smells of markets and explore ancient ruins, including a trek along the Inca Trail. As we operate our own treks, our quality equipment and the expertise of our porters and CEOs will ensure that your first glimpse of Machu Picchu will leave you in awe. Whether you're scanning the canopy for wildlife from the comfort of our intimate and exclusive G Lodge Amazon or following in the footsteps of the Incas, this fast-paced adventure provides a sweeping view of this diverse country.",
     "tour": {
         "href": "http://localhost:5000/tours/21346",

--- a/tests/test_live_api.py
+++ b/tests/test_live_api.py
@@ -55,10 +55,6 @@ class TourTestCase(TestCase):
     def setUp(self):
         self.tour = TourTestCase.tour
 
-    def test_get_itinerary(self):
-        itin = self.tour.get_brief_itinerary()
-        self.assertIsInstance(itin, list)
-
 
 @attr('integration')
 class TourDossierTestCase(TestCase):
@@ -69,10 +65,6 @@ class TourDossierTestCase(TestCase):
 
     def setUp(self):
         self.dossier = TourDossierTestCase.dossier
-
-    def test_get_itinerary(self):
-        itin = self.dossier.get_detailed_itinerary()
-        self.assertIsInstance(itin, list)
 
     def test_get_image_url(self):
         url = self.dossier.get_map_url()


### PR DESCRIPTION
This is preparatory work for the deprecation of the `tour_dossiers.itineraries` field.

**NB: This PR should probably be considered blocked until 4-Nov-2019 when we actually remove the field from the backend API responses.**

---

Prior to the removal on 4-Nov-2019, there _are_ two other dates of significance in this deprecation:

- 1-Aug-2019: the `itineraries` field of `tour_dossiers` _created after this date_ will only ever contain an empty list
- 9-Sep-2019: the `itineraries` field of _all_ `tour_dossiers` will show an empty list

As far as I can tell, the above milestones won't require any changes to gapipy. gapipy seems happy to construct a `TourDossier` instance from a dict containing either:

- an empty list in the `itineraries` field, or
- no `itineraries` field at all