### PR TITLE
Accept additional HTTP headers in `create` calls

### DIFF
--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -142,7 +142,7 @@ class Client(object):
 
         return resource_cls(data_dict, client=self, **kwargs)
 
-    def create(self, resource_name, data_dict):
+    def create(self, resource_name, data_dict, headers=None):
         """
         Create an instance of the specified resource with `data_dict`
         """
@@ -151,4 +151,4 @@ class Client(object):
         except AttributeError:
             raise AttributeError("No resource named %s is defined." % resource_name)
 
-        return resource_cls.create(self, data_dict)
+        return resource_cls.create(self, data_dict, headers=headers)

--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -177,9 +177,9 @@ class Query(object):
         self._filters = {}
         return out
 
-    def create(self, data_dict):
+    def create(self, data_dict, headers=None):
         """Create an instance of the query resource using the given data"""
-        return self.resource.create(self._client, data_dict)
+        return self.resource.create(self._client, data_dict, headers=headers)
 
     def first(self):
         """

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -142,13 +142,13 @@ class APIRequestor(object):
             uri = '/{0}/{1}'.format(self._get_uri(), resource_id)
         return self._request(uri, method, data=data)
 
-    def create(self, data, uri=None):
+    def create(self, data, uri=None, headers=None):
         """
         Create a single new resource with the given data.
         """
         if not uri:
             uri = '/{0}'.format(self._get_uri())
-        return self._request(uri, 'POST', data=data)
+        return self._request(uri, 'POST', data=data, additional_headers=headers)
 
     def list_raw(self, uri=None):
         """Return the raw response for listing resources.

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -41,9 +41,9 @@ class Resource(BaseModel):
         return self
 
     @classmethod
-    def create(cls, client, data_dict):
+    def create(cls, client, data_dict, headers=None):
         request = APIRequestor(client, cls)
-        response = request.create(json.dumps(data_dict))
+        response = request.create(json.dumps(data_dict), headers=headers)
         return cls(response, client=client)
 
     def __getattr__(self, name):

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -356,7 +356,7 @@ class UpdateCreateResourceTestCase(unittest.TestCase):
         r = MockResource(data, client=self.client)
         r.save()
         mock_request.assert_called_once_with(
-            '/mocks', 'POST', data=r.to_json())
+            '/mocks', 'POST', data=r.to_json(), additional_headers=None)
 
     def test_update_object(self, mock_request):
         data = {


### PR DESCRIPTION
Similar to what we do for `get` calls: https://github.com/gadventures/gapipy/commit/77ae9e055b26e24dd5438b5b1c1e7856c61a60ce

Basically, I'm after this functionality because I want to do some
testing of the auth ratelimiting of Trip Editor. The idea is that
gapi-layer passes the X-Forwarded-For header along to TE and TE can use
it to derive the actual client IP (to use in ratelimiting counts). The
TE auth endpoint gets hit when we attempt to *create* an oauth token.

I think that some system somewhere along the path is messing with that
header, though. Having the ability to inject my own X-Forwarded-For
header may help figure out what's happening.