### PR TITLE
Add `countries.{continent,place}` references

### DIFF
--- a/gapipy/resources/geo/country.py
+++ b/gapipy/resources/geo/country.py
@@ -17,6 +17,11 @@ class Country(Resource):
         'name',
     ]
 
+    _resource_fields = [
+        ('continent', 'Continent'),
+        ('place', 'Place'),
+    ]
+
     _resource_collection_fields = [
         ('states', State),
     ]


### PR DESCRIPTION
Just exposing some already-existing data on our `countries` resource (e.g. [`/countries/EG`](https://developers.gadventures.com/playground/countries/EG?env=live))

Aside: initially I had been importing the actual `Continent` and `Place` classes to pass in as the second element of the tuples added to `_resource_fields` ... that resulted in some circular import issues, but poking around in the rest of the codebase I see string references as well. From what I can tell, that seems to work here as well.