### PR TITLE
Raise an exception when `fetch`ing a stub fails

### DIFF
--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -34,10 +34,8 @@ class Resource(BaseModel):
         # Fetch the resource using the client bound on it, which handles cache get/set.
         resource_obj = getattr(self._client, self._resource_name).get(
             self.id,
-            variation_id=getattr(self, 'variation_id', None))
-
-        if resource_obj is None:
-            raise ValueError('Failed to hydrate stub %s/%s' % (self._resource_name, self.id))
+            variation_id=getattr(self, 'variation_id', None),
+            httperrors_mapped_to_none=None)
 
         if resource_obj:
             self._fill_fields(resource_obj._raw_data)

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -30,14 +30,19 @@ class Resource(BaseModel):
 
     def fetch(self):
         logger.info('Fetching %s/%s', self._resource_name, self.id)
-        self.is_stub = False
 
         # Fetch the resource using the client bound on it, which handles cache get/set.
         resource_obj = getattr(self._client, self._resource_name).get(
             self.id,
             variation_id=getattr(self, 'variation_id', None))
+
+        if resource_obj is None:
+            raise ValueError('Failed to hydrate stub %s/%s' % (self._resource_name, self.id))
+
         if resource_obj:
             self._fill_fields(resource_obj._raw_data)
+            self.is_stub = False
+
         return self
 
     @classmethod

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -37,9 +37,8 @@ class Resource(BaseModel):
             variation_id=getattr(self, 'variation_id', None),
             httperrors_mapped_to_none=None)
 
-        if resource_obj:
-            self._fill_fields(resource_obj._raw_data)
-            self.is_stub = False
+        self._fill_fields(resource_obj._raw_data)
+        self.is_stub = False
 
         return self
 

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -119,9 +119,18 @@ class QueryTestCase(unittest.TestCase):
         http_error = HTTPError(response=response)
         mock_request.side_effect = http_error
 
+        # default behaviour is to return None...
         query = Query(self.client, Tour)
-        t = query.get(1234)
-        self.assertIsNone(t)
+        self.assertIsNone(query.get(1234))
+
+        # ... but if this status code is not in the list of ones to explicitly
+        # turn into Nones, then it will get raised:
+        with self.assertRaises(HTTPError) as context:
+            query.get(1234, httperrors_mapped_to_none=None)
+
+        self.assertEqual(
+            context.exception.response.status_code,
+            response.status_code)
 
     @patch('gapipy.request.APIRequestor._request')
     def test_get_instance_with_non_existing_id(self, mock_request):
@@ -130,9 +139,18 @@ class QueryTestCase(unittest.TestCase):
         http_error = HTTPError(response=response)
         mock_request.side_effect = http_error
 
+        # default behaviour is to return None...
         query = Query(self.client, Tour)
-        t = query.get(1234)
-        self.assertIsNone(t)
+        self.assertIsNone(query.get(1234))
+
+        # ... but if this status code is not in the list of ones to explicitly
+        # turn into Nones, then it will get raised:
+        with self.assertRaises(HTTPError) as context:
+            query.get(1234, httperrors_mapped_to_none=None)
+
+        self.assertEqual(
+            context.exception.response.status_code,
+            response.status_code)
 
     @patch('gapipy.request.APIRequestor._request')
     def test_get_instance_with_gone_id(self, mock_request):
@@ -141,9 +159,18 @@ class QueryTestCase(unittest.TestCase):
         http_error = HTTPError(response=response)
         mock_request.side_effect = http_error
 
+        # default behaviour is to return None...
         query = Query(self.client, Tour)
-        t = query.get(1234)
-        self.assertIsNone(t)
+        self.assertIsNone(query.get(1234))
+
+        # ... but if this status code is not in the list of ones to explicitly
+        # turn into Nones, then it will get raised:
+        with self.assertRaises(HTTPError) as context:
+            query.get(1234, httperrors_mapped_to_none=None)
+
+        self.assertEqual(
+            context.exception.response.status_code,
+            response.status_code)
 
     @patch('gapipy.request.APIRequestor._request')
     def test_get_instance_by_id_with_non_404_error(self, mock_request):
@@ -152,11 +179,20 @@ class QueryTestCase(unittest.TestCase):
         http_error = HTTPError(response=response)
         mock_request.side_effect = http_error
 
+        # default behaviour is to raise...
         query = Query(self.client, Tour)
-        with self.assertRaises(HTTPError) as cm:
+        with self.assertRaises(HTTPError) as context:
             query.get(1234)
 
-        self.assertEqual(cm.exception.response.status_code, 401)
+        self.assertEqual(
+            context.exception.response.status_code,
+            response.status_code)
+
+        # ... but if we don't want that exception raised, then we can include
+        # that status code in our `httperrors_mapped_to_none` and verify that a
+        # `None` is returned:
+        self.assertIsNone(
+            query.get(1234, httperrors_mapped_to_none=[response.status_code]))
 
     @patch('gapipy.request.APIRequestor._request')
     def test_filtered_query(self, mock_request):

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -7,10 +7,9 @@ import sys
 from unittest import TestCase
 
 from mock import patch
-from requests.exceptions import HTTPError
 
 from gapipy.client import Client
-from gapipy.query import HTTPERRORS_MAPPED_TO_NONE, Query
+from gapipy.query import Query
 from gapipy.models import DATE_FORMAT, AccommodationRoom
 from gapipy.resources import (
     ActivityDossier,
@@ -97,72 +96,6 @@ class ResourceTestCase(TestCase):
             t.departures_end_date,
             datetime.datetime.strptime('2014-01-01', DATE_FORMAT).date()
         )
-
-    def test_populate_bad_stub(self):
-        """Calling fetch on an invalid stub should raise an exception"""
-
-        class NormallyIgnoredHTTPError(HTTPError):
-            """A dummy exception class with one of the error codes that
-            `Query.get` maps to `None` by default.
-
-            In this test we want to see that `fetch` will actually allow this
-            exception to be raised, unlike that default `get` behaviour.
-            """
-            status_code = HTTPERRORS_MAPPED_TO_NONE[0]
-
-        class Bar(Resource):
-            """A dummy resource with some non-ID field"""
-            _resource_name = 'bars'
-            _as_is_fields = ['id']
-            _date_fields = ['date']
-
-        def get_bars_query():
-            """Return a `Query` instance for our `Bar` resource to be patched
-            onto our client for testing.
-            """
-            return Query(self.client, Bar)
-
-        class Foo(Resource):
-            """A dummy resource that has a reference to our other dummy, Bar"""
-            _resource_name = 'foos'
-            _resource_fields = [('bar', Bar)]
-
-        # Create a Foo instance with a stub-reference to a Bar
-        f = Foo({
-            'bar': {
-                'id': 'shoobeedoobeedoo',
-            }
-        }, client=self.client)
-
-        # Patch our client-instance with a Query for the `bars` resource, and
-        # mock out its `get_resource_data` method...
-        with patch.object(self.client, 'bars', new_callable=get_bars_query, create=True) as mock_bars:
-            with patch.object(mock_bars, 'get_resource_data', create=True) as mock_get_resource_data:
-
-                # ... configure it to raise an HTTPError (with a status_code
-                # Query.get would ignore by default)...
-                mock_get_resource_data.side_effect = NormallyIgnoredHTTPError
-                mock_get_resource_data.return_value = None
-
-                # ... and then try to access an attribute that's not in the
-                # stub. This triggers a `Resource.fetch` which triggers a
-                # `Query.get` and a `Query.get_resource_data` -- which has been
-                # mocked to raise an exception
-                #
-                # This test makes sure that `Query.get` and `Resource.fetch`
-                # allow the error from `Query.get_resource_data` to escape up
-                # to the caller
-                with self.assertRaises(NormallyIgnoredHTTPError):
-                    print(f.bar.date)
-
-                # Make sure that our mock was used as intended
-                mock_get_resource_data.assert_called_once_with(
-                    f.bar.id,
-                    variation_id=None,
-                    cached=True,
-                    headers=None,
-                )
-
 
     def test_model_fields(self):
         from gapipy.models.base import BaseModel


### PR DESCRIPTION
tl;dr I want better error messages for invalid stubs

This is coming out of some discussions that Craig N and I were having
the other day, but this is an issue that has come up a number of times
sporadically in the past.

Today, gapipy swallows some HTTP errors silently (see
`gapipy.query.HTTPERRORS_MAPPED_TO_NONE`). This behaviour kind of makes
sense for the case where you are explicitly `get`ing that resource,
because you can check for that None condition:

    my_departure = g.departures.get(SOME_ID)
    if my_departure is None:
        pass # or do some things

On the other hand, this behaviour is kind of confusing when you're
working with a stub that is embedded in another resource. For example if
I have a `tour_dossiers` instance and I want the name of the corresponding
booking company, I can do something like the following:

    bc_name = my_tour_dossier.booking_companies[0].name

If the reference is correct, this all works fine. If the reference is to
a `booking_companies` that does not exist, or has been deleted or to which
I have no access, though, today gapipy will:

- try and fail to fetch the `booking_companies` by its ID
- try to access the `name` attribute anyway
- throw an AttributeError, claiming that "BookingCompany has no field
name available"

This is of course, a bunch of nonsense: booking companies _do_ have
names, we've simply failed to hydrate a broken reference.

Even if I were to do something like explicitly fetch that reference
before traversing, there's no way for me to see the None that gets
returned, my stub is still a stub.

---

This PR checks for the returned None when `fetch`ing a stub's data, and
raises a more descriptive exception.

NB: I think it could make sense to have some custom exception type for
this instead of using ValueError. Today gapipy doesn't seem to have any
custom exceptions types, though. I'm willing to add it, but figured we
can discuss this idea before ironing that kind of stuff out.