### PR TITLE
Improve filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ gapipy.egg-info/*
 .idea/
 .tox/
 .eggs/
+.python-version

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ gapipy.egg-info/*
 .idea/
 .tox/
 .eggs/
-.python-version

--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -96,8 +96,6 @@ class Query(object):
         something Falsey as `httperrors_mapped_to_none` like a `None` or an
         empty list.
         """
-        key = self.query_key(resource_id, variation_id) # noqa
-
         try:
             data = self.get_resource_data(
                 resource_id,

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -309,8 +309,8 @@ class QueryTestCase(unittest.TestCase):
         mock_request.assert_called_once_with(
             '/tour_dossiers', 'GET', params={})
 
-    def test_fetch_all_with_wrong_argument_for_limit(self):
-        message = '`limit` must be a positive integer'
+    def test_fetch_all_with_negative_arg_for_limit(self):
+        message = 'limit must be a positive integer'
         if sys.version_info.major < 3:
             with self.assertRaisesRegexp(ValueError, message):
                 query = Query(self.client, Tour).all(limit=-1)
@@ -319,6 +319,20 @@ class QueryTestCase(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, message):
                 query = Query(self.client, Tour).all(limit=-1)
                 list(query)  # force the query to evaluate
+
+    def test_fetch_all_with_wrong_arg_types_for_limit(self):
+        wrong_arg_types = ['', [], {}, object()]
+        message = 'limit must be an integer'
+
+        for wrong_arg in wrong_arg_types:
+            if sys.version_info.major < 3:
+                with self.assertRaisesRegexp(TypeError, message):
+                    query = Query(self.client, Tour).all(limit=wrong_arg)
+                    list(query)  # force the query to evaluate
+            else:
+                with self.assertRaisesRegex(TypeError, message):
+                    query = Query(self.client, Tour).all(limit=wrong_arg)
+                    list(query)  # force the query to evaluate
 
 
 class QueryCacheTestCase(unittest.TestCase):


### PR DESCRIPTION
**Task**: [Click](https://app.clickup.com/t/3a949y)

**Description:**  Query methods ( .filter() and .count() ) were clearing _filters attribute which resulted in single usage of a filtered query instance.

**Reproduce**: 
```python
In [3]: reproduce = api.tours.filter(product_line='PPP')
In [4]: reproduce._filters
Out[4]: {'product_line': 'PPP'}
In [5]: reproduce.count()
Out[5]: 1
In [6]: reproduce._filters
Out[6]: {}
In [7]: reproduce.count()
Out[7]: 1249
```
_and_
```python
 >>> len([x for x in g.departures.filter(**{'tour_dossier.id': '22758'}).all()])
    280
>>> len([x for x in g.departures.filter(**{'structured_itineraries.variation_id': 4364}).all()])
    0
```
```python
 >>> len([x for x in g.departures.filter(**{'structured_itineraries.variation_id': 4364}).all()])
    91
 >>> len([x for x in g.departures.filter(**{'tour_dossier.id': '22758'}).all()])
    0
```

**Solution:** Mimic Django ORM approach as close as possible