### PR TITLE
Migrating utility methods from django-gapi-hooked

### DIFF
--- a/gapipy/utils.py
+++ b/gapipy/utils.py
@@ -2,6 +2,8 @@
 # Python 2 and 3
 from __future__ import unicode_literals
 
+import hashlib
+import hmac
 import sys
 from functools import partial, wraps
 from importlib import import_module
@@ -169,3 +171,41 @@ def enforce_string_type(func):
         return func(*args, **kwargs).encode('utf-8')
 
     return wrapper
+
+
+def encode_if_not_bytes(data):
+    # This works in Py2 and 3: `bytes` is just an alias for `str` for Python 2
+    # versions since 2.6 (https://docs.python.org/3/whatsnew/2.6.html#pep-3112-byte-literals)
+    if isinstance(data, bytes):
+        return data
+
+    data = data.encode('utf-8')
+    return data
+
+
+def compute_request_signature(app_key, request_body):
+    """
+    Given an application key and request body, compute the signature as
+    directed by:
+        https://developers.gadventures.com/docs/webhooks.html#verifying-a-webhook
+
+    To verify that incoming webhooks are coming from the G API, we check
+    that this value matches the data in the request's `X-Gapi-Signature`
+    header.
+    """
+    return hmac.new(
+        encode_if_not_bytes(app_key),
+        encode_if_not_bytes(request_body),
+        hashlib.sha256).hexdigest()
+
+def compute_webhook_validation_key(app_key):
+    """
+    Given an application key, compute the SHA256 hex digest (aka "Webhooks
+    Validation Key") as directed by:
+        https://developers.gadventures.com/docs/webhooks.html#registering-a-webhook
+
+    To successfully respond to incoming webhooks we include this value in
+    our response's `X-Application-SHA256` header.
+    """
+    return hashlib.sha256(
+        encode_if_not_bytes(app_key)).hexdigest()


### PR DESCRIPTION
**Why are these methods being moved here?**
They exist in another project which has Django as a dependency. We have a non-Django app which uses these methods and it feels like an over-kill to also include Django libraries when we don't need them. 

**Will these methods be removed from the other project? i.e. `django-gapi-hooked` ?**
Not any time soon. After this PR is merged, I might add a note/comment in the code, but no plans to delete it right now. This is because I don't want to break any other project accidentally. 

**Will the documentation be updated to reflect the existence of these methods here?**
Yes. At least, I'm looking to update these pages;
https://developers.gadventures.com/docs/webhooks.html#registering-a-webhook
https://developers.gadventures.com/docs/webhooks.html#verifying-a-webhook
after this PR is merged. 