### PR TITLE
Fix-#121 - modify APIRequestor.list_raw to check the URI for params

### DIFF
--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -1,12 +1,14 @@
-import requests
 import sys
 from uuid import uuid1
 
+import requests
+
 from . import __title__, __version__
 
-
 ACCEPTABLE_RESPONSE_STATUS_CODES = (
-    requests.codes.ok, requests.codes.created, requests.codes.accepted,
+    requests.codes.ok,        # 200
+    requests.codes.created,   # 201
+    requests.codes.accepted,  # 202
 )
 
 ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', ]

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -1,4 +1,5 @@
 import sys
+from urlparse import urlparse
 from uuid import uuid1
 
 import requests
@@ -165,8 +166,8 @@ class APIRequestor(object):
         # called and as GAPI's next hrefs preserve the parameter filters, we
         # don't want to duplicate them.
         if uri:
-            # assume we have parameters
-            if '?' in uri:
+            # check if we have query parameters
+            if urlparse(uri).query:
                 return self._request(uri, 'GET')
             # otherwise use the params this requestor was initialised with
             return self._request(uri, 'GET', params=self.params)
@@ -175,7 +176,7 @@ class APIRequestor(object):
         #
         # if this requestor has a parent, it implies we're fetching nested-list
         # of the resource. We need to build the uri prefix in the form
-        # /parent/{id}[/{variation_id}]/{self._get_uri()
+        # /parent/{id}[/{variation_id}]/{self._get_uri()}
         #
         # parent is a 3-Tuple. See: BaseModel._set_resource_collection_field
         if self.parent:

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -168,12 +168,12 @@ class APIRequestor(object):
             # assume we have parameters
             if '?' in uri:
                 return self._request(uri, 'GET')
-            # otherwise use the params this Requester was initialised with
+            # otherwise use the params this requestor was initialised with
             return self._request(uri, 'GET', params=self.params)
 
         # No uri provided, build it and request it
         #
-        # if this requester has a parent, it implies we're fetching nested-list
+        # if this requestor has a parent, it implies we're fetching nested-list
         # of the resource. We need to build the uri prefix in the form
         # /parent/{id}[/{variation_id}]/{self._get_uri()
         #

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -181,10 +181,10 @@ class APIRequestor(object):
         # parent is a 3-Tuple. See: BaseModel._set_resource_collection_field
         if self.parent:
             parts = [
-                self.parent[0],  # parent uri
-                self.parent[1],  # parent id
-                self.parent[2],  # parent variation id
-                self._get_uri(), # self uri
+                self.parent.uri,
+                self.parent.id,
+                self.parent.variation_id,
+                self._get_uri(),
             ]
             uri = '/{0}'.format('/'.join(filter(None, parts)))
         else:

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 
 import json
 import logging
-from gapipy.request import APIRequestor
-from gapipy.models.base import BaseModel
-from gapipy.utils import enforce_string_type
 
+from gapipy.models.base import BaseModel
+from gapipy.request import APIRequestor
+from gapipy.utils import enforce_string_type
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -50,6 +50,32 @@ class APIRequestorTestCase(unittest.TestCase):
         mock_request.assert_called_once_with('/resources', 'GET', params=None)
 
     @patch('gapipy.request.APIRequestor._request')
+    def test_list_raw_uri_requestor_params(self, mock_request):
+        params = {'param': 'value'}
+        requestor = APIRequestor(self.client, self.resources, params=params)
+        requestor.list_raw('/test_uri')
+        mock_request.assert_called_once_with('/test_uri', 'GET', params=params)
+
+    @patch('gapipy.request.APIRequestor._request')
+    def test_list_raw_uri_no_requestor_params(self, mock_request):
+        requestor = APIRequestor(self.client, self.resources)
+        requestor.list_raw('/test_uri')
+        mock_request.assert_called_once_with('/test_uri', 'GET', params=None)
+
+    @patch('gapipy.request.APIRequestor._request')
+    def test_list_raw_uri_params_requestor_params(self, mock_request):
+        params = {'param': 'value'}
+        requestor = APIRequestor(self.client, self.resources, params=params)
+        requestor.list_raw('/test_uri?')
+        mock_request.assert_called_once_with('/test_uri?', 'GET')
+
+    @patch('gapipy.request.APIRequestor._request')
+    def test_list_raw_uri_params_no_requestor_params(self, mock_request):
+        requestor = APIRequestor(self.client, self.resources)
+        requestor.list_raw('/test_uri?')
+        mock_request.assert_called_once_with('/test_uri?', 'GET')
+
+    @patch('gapipy.request.APIRequestor._request')
     def test_list_resource_with_parent(self, mock_request):
         parent = ('parent', '1234', None)
         requestor = APIRequestor(self.client, self.resources, parent=parent)

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -4,6 +4,7 @@ import unittest
 from mock import call, patch
 
 from gapipy.client import Client
+from gapipy.models.base import _Parent
 from gapipy.request import APIRequestor
 
 from .fixtures import FIRST_PAGE_LIST_DATA, SECOND_PAGE_LIST_DATA
@@ -77,7 +78,7 @@ class APIRequestorTestCase(unittest.TestCase):
 
     @patch('gapipy.request.APIRequestor._request')
     def test_list_resource_with_parent(self, mock_request):
-        parent = ('parent', '1234', None)
+        parent = _Parent('parent', '1234', None)
         requestor = APIRequestor(self.client, self.resources, parent=parent)
         requestor.list_raw()
         mock_request.assert_called_once_with(

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -67,13 +67,13 @@ class APIRequestorTestCase(unittest.TestCase):
         params = {'param': 'value'}
         requestor = APIRequestor(self.client, self.resources, params=params)
         requestor.list_raw('/test_uri?')
-        mock_request.assert_called_once_with('/test_uri?', 'GET')
+        mock_request.assert_called_once_with('/test_uri?', 'GET', params=params)
 
     @patch('gapipy.request.APIRequestor._request')
     def test_list_raw_uri_params_no_requestor_params(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.list_raw('/test_uri?')
-        mock_request.assert_called_once_with('/test_uri?', 'GET')
+        mock_request.assert_called_once_with('/test_uri?', 'GET', params=None)
 
     @patch('gapipy.request.APIRequestor._request')
     def test_list_resource_with_parent(self, mock_request):


### PR DESCRIPTION
This truly fixes #113. Specifically:

```python
In [5]: len([d for d in g.tour_dossiers.get(24821).departures.filter(start_date__gte='2019-09-20')])
Out[5]: 1247
```

The reason this wasn't working even after #121 was due to the addition of `href` in the call to `requestor.list`: https://github.com/gadventures/gapipy/blob/95a6c4df2348c8340083bc62a8276d8e029fd676/gapipy/query.py#L179-L187

This resulted in the Query filter params being ignored in the `APIRequestor.list_raw` call.

We have modified the `APIRequestor.list_raw` method to check the passed `uri` for a `?`. If found, we will assume that the uri is providing its own query parameters and we will not modify them. Otherwise, we will use the params the requestor was initialised with.