### PR TITLE
Re: #113 - Fix Tour Dossier Departure nested Query

### DIFF
--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -2,12 +2,8 @@
 from __future__ import unicode_literals
 
 from gapipy.models import AdvertisedDeparture
-from gapipy.models.base import _Parent
-from gapipy.query import Query
 from gapipy.resources.base import Resource
 from gapipy.resources.booking_company import BookingCompany
-from gapipy.utils import get_resource_class_from_class_name
-
 
 MAP_IMAGE_TYPE = 'MAP'
 BANNER_IMAGE_TYPE = 'BANNER'
@@ -55,6 +51,7 @@ class TourDossier(Resource):
         for image in self.images:
             if image['type'] == image_type:
                 return image['image_href']
+        return None
 
     def get_map_url(self):
         return self._get_image_url(MAP_IMAGE_TYPE)
@@ -69,8 +66,10 @@ class TourDossier(Resource):
         for detail in self.details:
             if detail['detail_type']['label'] == label:
                 return detail['body']
+        return None
 
     def get_category_name(self, label):
         for category in self.categories:
             if category['category_type']['label'] == label:
                 return category['name']
+        return None

--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from gapipy.models import AdvertisedDeparture
+from gapipy.models.base import _Parent
 from gapipy.query import Query
 from gapipy.resources.base import Resource
 from gapipy.resources.booking_company import BookingCompany
@@ -15,6 +16,7 @@ BANNER_IMAGE_TYPE = 'BANNER'
 class TourDossier(Resource):
 
     _resource_name = 'tour_dossiers'
+    _is_parent_resource = True
 
     _as_is_fields = [
         'id',
@@ -29,35 +31,25 @@ class TourDossier(Resource):
         'site_links',
         'slug',
     ]
+
     _date_fields = [
         'departures_start_date',
         'departures_end_date',
     ]
+
     _resource_fields = [
         ('tour', 'Tour'),
     ]
+
     _resource_collection_fields = [
         ('departures', 'Departure'),
     ]
+
     _model_collection_fields = [
         ('advertised_departures', AdvertisedDeparture),
         ('booking_companies', BookingCompany),
         ('structured_itineraries', 'Itinerary'),
     ]
-
-    def _set_resource_collection_field(self, field, value):
-        """
-        Overridden to ensure that the `departures` query has the right
-        parent resource (i.e. the tour and not the tour dossier).
-        """
-        if field == 'departures':
-            resource_cls = get_resource_class_from_class_name('Departure')
-            # Tour dossiers always have the same id as the corresponding tour
-            parent = ('tours', self.id, None)
-            query = Query(self._client, resource_cls, parent=parent, raw_data=value)
-            setattr(self, field, query)
-        else:
-            return super(TourDossier, self)._set_resource_collection_field(field, value)
 
     def _get_image_url(self, image_type):
         for image in self.images:


### PR DESCRIPTION
Fix broken behaviour from adding `_Parent` namedtuple:

* Adding the `_Parent` namedtuple in models.base broke this existing behaviour when Querying for departures under a tour-dossier. (See https://github.com/gadventures/gapipy/pull/123/commits/53566380a5acc8cfffa88473d6e58a83f4fbbd96)

This borked the following behaviour with an `AttributeError` as noted in https://github.com/gadventures/gapipy/issues/113#issuecomment-616805414

```python
>>> from gapipy import Client
>>> g = Client(application_key="some_api_key")
>>> g.tour_dossiers.get(24821).departures.count()
```

The [`_set_resource_collection_field`](https://github.com/gadventures/gapipy/compare/tour-dossier-departure-query?expand=1#diff-25e4a03badf1a977147e1145fab01b20L48) override in `tour_dossier.py` can be removed as:
1. Tours have been deprecated
2. We are using an intermediate (Sieve) to enable pagination of `Departures`.