### PR TITLE
Adds "global_http_headers" config to "Client" ...

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,17 @@
 History
 =======
 
+Unreleased
+----------
+
+* Add a new ``Client`` config option, ``extra_http_headers``, a dict of HTTP
+  headers to add to each request made with that client.
+
+  This is similar to the ``headers=`` kwargs available when making ``get`` and
+  ``create`` calls, except that the ``extra_http_headers`` set on a client will
+  apply on *every request* made by that client instance.
+
+
 2.27.0 (2020-05-26)
 -------------------
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -6,11 +6,11 @@ History
 Unreleased
 ----------
 
-* Add a new ``Client`` config option, ``extra_http_headers``, a dict of HTTP
+* Add a new ``Client`` config option, ``global_http_headers``, a dict of HTTP
   headers to add to each request made with that client.
 
   This is similar to the ``headers=`` kwargs available when making ``get`` and
-  ``create`` calls, except that the ``extra_http_headers`` set on a client will
+  ``create`` calls, except that the ``global_http_headers`` set on a client will
   apply on *every request* made by that client instance.
 
 

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -25,7 +25,7 @@ default_config = {
     },
     'uuid': os.environ.get('GAPI_UUID', False),
     'max_retries': os.environ.get('GAPI_CLIENT_MAX_RETRIES', 0),
-    'extra_http_headers': {},
+    'global_http_headers': {},
 }
 
 
@@ -53,7 +53,7 @@ class Client(object):
         self.cache_backend = get_config(config, 'cache_backend')
         self.uuid = get_config(config, 'uuid')
         self.max_retries = get_config(config, 'max_retries')
-        self.extra_http_headers = get_config(config, 'extra_http_headers')
+        self.global_http_headers = get_config(config, 'global_http_headers')
 
         # begin with default connection pool options and overwrite any that the
         # client has specified

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -25,6 +25,7 @@ default_config = {
     },
     'uuid': os.environ.get('GAPI_UUID', False),
     'max_retries': os.environ.get('GAPI_CLIENT_MAX_RETRIES', 0),
+    'extra_http_headers': {},
 }
 
 
@@ -52,6 +53,7 @@ class Client(object):
         self.cache_backend = get_config(config, 'cache_backend')
         self.uuid = get_config(config, 'uuid')
         self.max_retries = get_config(config, 'max_retries')
+        self.extra_http_headers = get_config(config, 'extra_http_headers')
 
         # begin with default connection pool options and overwrite any that the
         # client has specified

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -61,9 +61,10 @@ class APIRequestor(object):
         # Start with an empty collection of headers
         headers = {}
 
-        # If our client was configured to send extra headers, include those
-        if self.client.extra_http_headers:
-            headers.update(self.client.extra_http_headers)
+        # If our client was configured to send some headers globally on all
+        # requests, include those
+        if self.client.global_http_headers:
+            headers.update(self.client.global_http_headers)
 
         # Add the identification + auth headers
         headers.update({

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -58,10 +58,15 @@ class APIRequestor(object):
     def _get_headers(self, method, additional_headers):
         """Return a dictionary of HTTP headers to set on the request to the API."""
 
+        # Start with identification + auth headers
         headers = {
             'User-Agent': '{0}/{1}'.format(__title__, __version__),
             'X-Application-Key': self.client.application_key,
         }
+
+        # If our client was configured to send extra headers, include those
+        if self.client.extra_http_headers:
+            headers.update(self.client.extra_http_headers)
 
         # gapipy works in JSON. Ensure the receiving API is aware of the type of
         # payload being sent.
@@ -71,6 +76,7 @@ class APIRequestor(object):
         if self.client.api_language:
             headers['Accept-Language'] = self.client.api_language
 
+        # If this specific call included additional headers, include them
         if additional_headers:
             headers.update(additional_headers)
 

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -58,15 +58,18 @@ class APIRequestor(object):
     def _get_headers(self, method, additional_headers):
         """Return a dictionary of HTTP headers to set on the request to the API."""
 
-        # Start with identification + auth headers
-        headers = {
-            'User-Agent': '{0}/{1}'.format(__title__, __version__),
-            'X-Application-Key': self.client.application_key,
-        }
+        # Start with an empty collection of headers
+        headers = {}
 
         # If our client was configured to send extra headers, include those
         if self.client.extra_http_headers:
             headers.update(self.client.extra_http_headers)
+
+        # Add the identification + auth headers
+        headers.update({
+            'User-Agent': '{0}/{1}'.format(__title__, __version__),
+            'X-Application-Key': self.client.application_key,
+        })
 
         # gapipy works in JSON. Ensure the receiving API is aware of the type of
         # payload being sent.

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -123,3 +123,43 @@ class APIRequestorTestCase(unittest.TestCase):
         params_arg = mock_make_call.call_args[0][-1]
         self.assertEqual(params_arg['test'], '1234')
         self.assertTrue('uuid' in params_arg)
+
+    def test_extra_headers_from_client(self):
+        """
+        The client's "extra_http_headers" should be included when generating
+        HTTP headers for a request.
+        """
+        header_name = "x-farnsworth"
+        header_value = "here's where I keep assorted lengths of wire",
+        self.client.extra_http_headers = {header_name: header_value}
+        requestor = APIRequestor(self.client, self.resources)
+
+        method = 'METHOD'
+        additional_headers = {}
+        request_headers = requestor._get_headers(method, additional_headers)
+
+        self.assertIn(header_name, request_headers)
+        self.assertEqual(request_headers[header_name], header_value)
+
+    def test_extra_headers_from_client_overriden_by_additional_headers(self):
+        """
+        The client's "extra_http_headers" should be included when generating
+        HTTP headers for a request, but are overridable by headers added later.
+        """
+        header_name = "x-farnsworth"
+        header_value = "here's where I keep assorted lengths of wire",
+        self.client.extra_http_headers = {header_name: header_value}
+        requestor = APIRequestor(self.client, self.resources)
+
+        method = 'METHOD'
+
+        # If `_get_headers` is given an `additional_headers` value with the
+        # same `header_name` as was in the client configs...
+        request_headers = requestor._get_headers(method, {
+            header_name: 'good news'
+        })
+
+        # ... the value from `additional_headers` will be the one in the final
+        # header-dict
+        self.assertIn(header_name, request_headers)
+        self.assertEqual(request_headers[header_name], 'good news')

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -124,14 +124,14 @@ class APIRequestorTestCase(unittest.TestCase):
         self.assertEqual(params_arg['test'], '1234')
         self.assertTrue('uuid' in params_arg)
 
-    def test_extra_headers_from_client(self):
+    def test_global_headers_from_client(self):
         """
-        The client's "extra_http_headers" should be included when generating
+        The client's "global_http_headers" should be included when generating
         HTTP headers for a request.
         """
         header_name = "x-farnsworth"
         header_value = "here's where I keep assorted lengths of wire",
-        self.client.extra_http_headers = {header_name: header_value}
+        self.client.global_http_headers = {header_name: header_value}
         requestor = APIRequestor(self.client, self.resources)
 
         method = 'METHOD'
@@ -141,14 +141,14 @@ class APIRequestorTestCase(unittest.TestCase):
         self.assertIn(header_name, request_headers)
         self.assertEqual(request_headers[header_name], header_value)
 
-    def test_extra_headers_from_client_overriden_by_additional_headers(self):
+    def test_global_headers_from_client_overriden_by_additional_headers(self):
         """
-        The client's "extra_http_headers" should be included when generating
+        The client's "global_http_headers" should be included when generating
         HTTP headers for a request, but are overridable by headers added later.
         """
         header_name = "x-farnsworth"
         header_value = "here's where I keep assorted lengths of wire",
-        self.client.extra_http_headers = {header_name: header_value}
+        self.client.global_http_headers = {header_name: header_value}
         requestor = APIRequestor(self.client, self.resources)
 
         method = 'METHOD'
@@ -164,9 +164,9 @@ class APIRequestorTestCase(unittest.TestCase):
         self.assertIn(header_name, request_headers)
         self.assertEqual(request_headers[header_name], 'good news')
 
-    def test_extra_headers_from_client_overriden_by_gapipy_headers(self):
+    def test_global_headers_from_client_overriden_by_gapipy_headers(self):
         """
-        The client's "extra_http_headers" should be included when generating
+        The client's "global_http_headers" should be included when generating
         HTTP headers for a request, but are overriden by some required headers
         added by gapipy.
         """
@@ -174,7 +174,7 @@ class APIRequestorTestCase(unittest.TestCase):
 
         # We'll set up some HTTP headers in our client config...
         header_value = "woob woob woob woob woob woob woob",
-        self.client.extra_http_headers = {
+        self.client.global_http_headers = {
             'Accept-Language': header_value,
             'User-Agent': header_value,
             'X-Application-Key': header_value,


### PR DESCRIPTION
... so that it becomes possible to specify some HTTP headers to include
with *every* request.

(This comes out of some discussion that Ammaar and Jakub and I were
having in the context of *internal* GAPI clients)