### PR TITLE
Relationships fields for Tour Dossiers & Departures

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,20 @@
 History
 =======
 
+Unreleased
+----------
+
+* Adds ``Departure.relationships`` field via  ``DepartureRelationship`` model
+* Adds ``TourDossier.relationships`` field via ``TourDossierRelationship``
+  model
+
+.. warning:: BREAKING change!
+
+* Moves the ``gapipy.resources.tour.itinerary.ValidDuringRange`` class over to
+  its own file ``gapipy.resources.tour._valid_during_range.ValidDuringRange``
+  so that it can be reused by the ``TourDossierRelationship`` model,
+
+
 2.28.0 (2020-11-23)
 -------------------
 

--- a/gapipy/resources/tour/_valid_during_range.py
+++ b/gapipy/resources/tour/_valid_during_range.py
@@ -1,0 +1,82 @@
+# pylint: disable=no-member
+import datetime
+
+from gapipy.models.base import BaseModel
+from gapipy.utils import enforce_string_type
+
+
+class ValidDuringRange(BaseModel):
+    _date_fields = [
+        'end_date',
+        'start_date',
+    ]
+
+    def is_expired(self):
+        return not self.is_valid_during_range(datetime.date.today(), None)
+
+    def is_valid_today(self):
+        return self.is_valid_on_date(datetime.date.today())
+
+    def is_valid_during_range(self, start_date, end_date):
+        if start_date and not end_date:
+            return self.is_valid_on_or_after_date(start_date)
+
+        if not start_date and end_date:
+            return self.is_valid_on_or_before_date(end_date)
+
+        if not start_date and not end_date:
+            return self.is_valid_sometime()
+
+        if start_date == end_date:
+            return self.is_valid_on_date(start_date)
+
+        # start_date and end_date are both not None and not equal
+        return (
+            start_date <= end_date
+        ) and (
+            self.is_valid_sometime()
+        ) and all([
+            self.start_date is None or self.start_date <= end_date,
+            self.end_date is None or self.end_date >= start_date,
+        ])
+
+    def is_valid_on_or_after_date(self, date):
+        return (
+            self.end_date is None
+        ) or (
+            self.start_date is None and
+            self.end_date >= date
+        ) or (
+            self.start_date is not None and
+            self.start_date <= self.end_date and
+            self.end_date >= date
+        )
+
+    def is_valid_on_or_before_date(self, date):
+        return (
+            self.start_date is None
+        ) or (
+            self.end_date is None and
+            self.start_date <= date
+        ) or (
+            self.end_date is not None and
+            self.start_date <= self.end_date and
+            self.start_date <= date
+        )
+
+    def is_valid_on_date(self, date):
+        return all([
+            self.start_date is None or self.start_date <= date,
+            self.end_date is None or self.end_date >= date,
+        ])
+
+    def is_valid_sometime(self):
+        return (
+            self.start_date is None or
+            self.end_date is None or
+            self.start_date <= self.end_date
+        )
+
+    @enforce_string_type
+    def __repr__(self):
+        return '<{} ({} - {})>'.format(self.__class__.__name__, self.start_date, self.end_date)

--- a/gapipy/resources/tour/departure.py
+++ b/gapipy/resources/tour/departure.py
@@ -18,6 +18,16 @@ class LocalPayment(BaseModel):
     ]
 
 
+class Relationship(BaseModel):
+    _as_is_fields = [
+        'type',
+        'sub_type',
+    ]
+    _resource_fields = [
+        ('departure', 'Departure'),
+    ]
+
+
 class Departure(Product):
 
     _resource_name = 'departures'
@@ -68,6 +78,7 @@ class Departure(Product):
         ('booking_companies', BookingCompany),
         ('local_payments', LocalPayment),
         ('lowest_pp2a_prices', PP2aPrice),
+        ('relationships', Relationship),
         ('rooms', DepartureRoom),
         ('structured_itineraries', 'Itinerary'),
     ]

--- a/gapipy/resources/tour/departure.py
+++ b/gapipy/resources/tour/departure.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Python 2 and 3
 from __future__ import unicode_literals
 
@@ -18,7 +19,7 @@ class LocalPayment(BaseModel):
     ]
 
 
-class Relationship(BaseModel):
+class DepartureRelationship(BaseModel):
     _as_is_fields = [
         'type',
         'sub_type',
@@ -78,7 +79,7 @@ class Departure(Product):
         ('booking_companies', BookingCompany),
         ('local_payments', LocalPayment),
         ('lowest_pp2a_prices', PP2aPrice),
-        ('relationships', Relationship),
+        ('relationships', DepartureRelationship),
         ('rooms', DepartureRoom),
         ('structured_itineraries', 'Itinerary'),
     ]

--- a/gapipy/resources/tour/itinerary.py
+++ b/gapipy/resources/tour/itinerary.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Python 2 and 3
+# pylint: disable=no-member
 from __future__ import unicode_literals
-
-import datetime
 
 from gapipy.models.base import BaseModel
 from gapipy.resources.base import Resource
@@ -14,6 +13,9 @@ from gapipy.utils import (
     duration_label,
     enforce_string_type,
 )
+
+from ._valid_during_range import ValidDuringRange
+
 
 class RippleScore(BaseModel):
     _as_is_fields = [
@@ -113,83 +115,6 @@ class ItineraryDay(BaseModel):
     @enforce_string_type
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, self.day)
-
-
-class ValidDuringRange(BaseModel):
-    _date_fields = [
-        'end_date',
-        'start_date',
-    ]
-
-    def is_expired(self):
-        return not self.is_valid_during_range(datetime.date.today(), None)
-
-    def is_valid_today(self):
-        return self.is_valid_on_date(datetime.date.today())
-
-    def is_valid_during_range(self, start_date, end_date):
-        if start_date and not end_date:
-            return self.is_valid_on_or_after_date(start_date)
-
-        if not start_date and end_date:
-            return self.is_valid_on_or_before_date(end_date)
-
-        if not start_date and not end_date:
-            return self.is_valid_sometime()
-
-        if start_date == end_date:
-            return self.is_valid_on_date(start_date)
-
-        # start_date and end_date are both not None and not equal
-        return (
-            start_date <= end_date
-        ) and (
-            self.is_valid_sometime()
-        ) and all([
-            self.start_date is None or self.start_date <= end_date,
-            self.end_date is None or self.end_date >= start_date,
-        ])
-
-    def is_valid_on_or_after_date(self, date):
-        return (
-            self.end_date is None
-        ) or (
-            self.start_date is None and
-            self.end_date >= date
-        ) or (
-            self.start_date is not None and
-            self.start_date <= self.end_date and
-            self.end_date >= date
-        )
-
-    def is_valid_on_or_before_date(self, date):
-        return (
-            self.start_date is None
-        ) or (
-            self.end_date is None and
-            self.start_date <= date
-        ) or (
-            self.end_date is not None and
-            self.start_date <= self.end_date and
-            self.start_date <= date
-        )
-
-    def is_valid_on_date(self, date):
-        return all([
-            self.start_date is None or self.start_date <= date,
-            self.end_date is None or self.end_date >= date,
-        ])
-
-    def is_valid_sometime(self):
-        return (
-            self.start_date is None or
-            self.end_date is None or
-            self.start_date <= self.end_date
-        )
-
-    @enforce_string_type
-    def __repr__(self):
-        return '<{} ({} - {})>'.format(self.__class__.__name__, self.start_date, self.end_date)
 
 
 class DetailType(BaseModel):

--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -2,11 +2,28 @@
 from __future__ import unicode_literals
 
 from gapipy.models import AdvertisedDeparture
+from gapipy.models.base import BaseModel
 from gapipy.resources.base import Resource
 from gapipy.resources.booking_company import BookingCompany
 
+from ._valid_during_range import ValidDuringRange
+
+
 MAP_IMAGE_TYPE = 'MAP'
 BANNER_IMAGE_TYPE = 'BANNER'
+
+
+class Relationship(BaseModel):
+    _as_is_fields = [
+        'type',
+        'sub_type',
+    ]
+    _resource_fields = [
+        ('tour_dossier', 'TourDossier'),
+    ]
+    _model_collection_fields = [
+        ('valid_during_ranges', ValidDuringRange),
+    ]
 
 
 class TourDossier(Resource):
@@ -44,6 +61,7 @@ class TourDossier(Resource):
     _model_collection_fields = [
         ('advertised_departures', AdvertisedDeparture),
         ('booking_companies', BookingCompany),
+        ('relationships', Relationship),
         ('structured_itineraries', 'Itinerary'),
     ]
 

--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Python 2 and 3
 from __future__ import unicode_literals
 
@@ -13,7 +14,7 @@ MAP_IMAGE_TYPE = 'MAP'
 BANNER_IMAGE_TYPE = 'BANNER'
 
 
-class Relationship(BaseModel):
+class TourDossierRelationship(BaseModel):
     _as_is_fields = [
         'type',
         'sub_type',
@@ -61,7 +62,7 @@ class TourDossier(Resource):
     _model_collection_fields = [
         ('advertised_departures', AdvertisedDeparture),
         ('booking_companies', BookingCompany),
-        ('relationships', Relationship),
+        ('relationships', TourDossierRelationship),
         ('structured_itineraries', 'Itinerary'),
     ]
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -3,7 +3,6 @@
 from __future__ import unicode_literals
 
 import datetime
-import sys
 from unittest import TestCase
 
 from mock import patch
@@ -12,7 +11,6 @@ from gapipy.client import Client
 from gapipy.query import Query
 from gapipy.models import DATE_FORMAT, AccommodationRoom
 from gapipy.resources import (
-    ActivityDossier,
     Departure,
     Itinerary,
     Promotion,
@@ -20,7 +18,7 @@ from gapipy.resources import (
     TourDossier,
 )
 from gapipy.resources.base import Resource
-from gapipy.resources.tour.itinerary import ValidDuringRange
+from gapipy.resources.tour._valid_during_range import ValidDuringRange
 
 from .fixtures import DUMMY_DEPARTURE, PPP_TOUR_DATA, PPP_DOSSIER_DATA
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,18 +2,14 @@
 # Python 2 and 3
 from __future__ import unicode_literals
 
-import sys
 from unittest import TestCase
 
-from gapipy.client import Client
-from gapipy.resources.base import Resource
 from gapipy.utils import (
     duration_label,
     humanize_amount,
     humanize_price,
     humanize_time,
     location_label,
-    enforce_string_type,
     compute_request_signature,
     compute_webhook_validation_key,
 )


### PR DESCRIPTION
Adds `relationships` fields to Both Tour Dossiers and Departures resources.

* `Departure.relationships` exposes related Departures
* `TourDossier.relationships` exposes related Tour Dossiers
* There will always be a correlation between the `departure.relationships[x].departure.tour_dossier` and a `tour_dossier.relationships[y].tour_dossier`.
  * NOTE: using x, y as the index ordering may differ
  * These relationships have `0..*`association

+ Moves the `ValidDuringRange` into its own file so we can import it into both Resources
  + Any system accessing the `ValidDuringRange` model directly will need to make changes in order to avoid breaking existing code.
  + Replacing existing code:
    ```python
    # broken
    from gapipy.resources.tour.itinerary import ValidDuringRange

    # replace with
    from gapipy.resources.tour._valid_during_range import ValidDuringRange
    ```

## Departure.relationships

* `Departure.relationships` will list other departures that can be associated with the primary departure.
  * They contain a `type` and `sub_type` field that denote the nature of the departure.
  * `type` is currently limited to `MINI_ADVENTURE` but other values may be added in the future.
    * A `MINI_ADVENTURE` is for all intents and purposes a regular departure, except that it's duration will be on the order of 2-4 days long
  * `sub_type` is currently limited to `PRE_TOUR` and `POST_TOUR` values, but other values may be added in the future.
    * `PRE_TOUR`: signifies that the related departure may only be booked prior to the primary departure.
    * `POST_TOUR`: signifies that the related departure may only be booked after the primary departure.

  ### JSON structure:

  ``` json
  {"relationships": [
      {
          "type": "MINI_ADVENTURE",
          "sub_type": "PRE_TOUR",
          "departure": {
              "id": "1131818",
              "href": "https://rest.gadventures.com/departures/1131818",
              "start_date": "2021-08-26"
          }
      }
  ]}
  ```
  ### gapipy (Python) access:
  ``` python
  from gapipy import Client

  gapi = Client(application_key="live_my-secret-gapi-key")
  dep = gapi.departures.get(1011030)
  # <Departure: 1011030>

  for r in dep.relationships:
      print(r.type, r.sub_type, r.departure)
      print(r.departure.id, r.departure.name)
  # MINI_ADVENTURE PRE_TOUR <Departure: 1131818 (stub)>
  # 1131818 Classic Quito Mini Adventure
  ```

## TourDossier.relationships

* `TourDossier.relationships` will list other Tour Dossiers that can be associated with the primary Tour Dossier.
  * The `relationship` contains a `type` and `sub_type` field that denote the nature of the Tour Dossier.
    * `type` is currently limited to `MINI_ADVENTURE` but other values may be added in the future.
    * `sub_type` is currently limited to `PRE_TOUR` and `POST_TOUR` values, but other values may be added in the future.
      * `PRE_TOUR`: signifies that the related departure may only be booked prior to the primary departure.
      * `POST_TOUR`: signifies that the related departure may only be booked after the primary departure.
  * It contains a referenced to the related `Tour Dossier`
  * It also provide a list of `ValidDuringRange` objects that contain a `start_date` and `end_date` denoting the period during which this related Tour Dossier can be validly associated with the primary Tour Dossier.

  ### JSON structure:

  ``` json
  {"relationships": [
      {
          "type": "MINI_ADVENTURE",
          "sub_type": "PRE_TOUR",
          "tour_dossier": {
              "id": "25521",
              "href": "https://rest.gadventures.com/tour_dossiers/25521",
              "product_line": "RSEPQN"
          },
          "valid_during_ranges": [
              {
                  "start_date": "2021-09-01",
                  "end_date": null
              }
          ]
      }
  ]}
  ```
  ### gapipy (Python) access:
  ``` python
  from gapipy import Client

  gapi = Client(application_key="live_my-secret-gapi-key")
  dossier = gapi.tour_dossiers.get(22896)
  # <TourDossier: 22896>

  for r in dossier.relationships:
      print(r.type, r.sub_type, r.tour_dossier)
      print(r.tour_dossier.id, r.tour_dossier.name)
      print(r.valid_during_ranges)
  # MINI_ADVENTURE PRE_TOUR <TourDossier: 25521>
  # 25521 Classic Quito Mini Adventure
  # [<ValidDuringRange (2021-09-01 - None)>]
  ```
  