### PR TITLE
restore old fetch() behaviour

### DIFF
--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -29,6 +29,11 @@ class Resource(BaseModel):
         return APIRequestor(client, cls).options()
 
     def fetch(self, httperrors_mapped_to_none=None):
+        """
+        httperrors_mapped_to_none is a list of HTTP errors we will silently absorb (i.e.
+        not float up). This brings back behavior prior to 2.25.0.
+        ref: https://github.com/gadventures/gapipy/pull/119
+        """
         logger.info('Fetching %s/%s', self._resource_name, self.id)
 
         # Fetch the resource using the client bound on it, which handles cache get/set.

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -28,17 +28,17 @@ class Resource(BaseModel):
     def options(cls, client):
         return APIRequestor(client, cls).options()
 
-    def fetch(self):
+    def fetch(self, httperrors_mapped_to_none=None):
         logger.info('Fetching %s/%s', self._resource_name, self.id)
 
         # Fetch the resource using the client bound on it, which handles cache get/set.
         resource_obj = getattr(self._client, self._resource_name).get(
             self.id,
             variation_id=getattr(self, 'variation_id', None),
-            httperrors_mapped_to_none=None)
-
-        self._fill_fields(resource_obj._raw_data)
-        self.is_stub = False
+            httperrors_mapped_to_none=httperrors_mapped_to_none)
+        if resource_obj:
+            self._fill_fields(resource_obj._raw_data)
+            self.is_stub = False
 
         return self
 


### PR DESCRIPTION
The motivation for this PR comes from upgrading the version of gapipy from `2.24.3` to `2.30.1` in another project. I assumed it would be a simple update, but doing so raised multiple unit test errors. 

Some of these errors are caused because of changes in how `fetch()` operates. Take the following code snippet,
```python
self.booking = self.departure_service.booking.fetch()
```

With `2.24.3` , the above would return a booking object.
With `2.30.1` , the above throws an exception - something about invalid remote requests; status 403

My ideal fix for this situation would be to refactor the unit tests so that they no longer make remote requests. Sadly, this would be too time-consuming, so I'm looking for work-arounds. 

The first idea which popped in my head was to bring back the old behaviour - which is what this PR proposes.

Assuming this PR is accepted, it will mean updating the unit tests in my other project to look like this,
```python
self.booking = self.departure_service.booking.fetch(old_behaviour=True)
```

That _feels_ ugly to me, but after a few days of digging into rabbit holes, I can't think of anything else. 😖 