### PR TITLE
introduce new constants.py file

### DIFF
--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
-__version__ = '2.30.1'
-__title__ = 'gapipy'
+__title__ = "gapipy"
 
-from .client import Client  # NOQA
+__version__ = "2.30.1"
+
+from .client import Client  # noqa

--- a/gapipy/constants.py
+++ b/gapipy/constants.py
@@ -1,0 +1,18 @@
+from requests.status_codes import codes
+
+# The default set of HTTP Status codes that will result in Query.get
+# returning a `None` value.
+#
+# Since 2.25.0 (See: https://github.com/gadventures/gapipy/pull/119)
+#
+# This is now passed as default parameter to `Query.get`. This has allowed
+# a slight modification to the behaviour of Resource.fetch, which now passes
+# in an explicit `None` value for `httperrors_mapped_to_none` kwarg.`Query.get`
+# will now raise the requests.HTTTPError when an attempt to `fetch` stub fails,
+# providing more expressive errors to be bubbled up.
+HTTPERRORS_MAPPED_TO_NONE = (
+    codes.FORBIDDEN,  # 403
+    codes.NOT_FOUND,  # 404
+    codes.GONE,       # 410
+)
+

--- a/gapipy/constants.py
+++ b/gapipy/constants.py
@@ -1,5 +1,17 @@
 from requests.status_codes import codes
 
+# Date formats
+
+# ISO Date
+DATE_FORMAT = "%Y-%m-%d"
+
+# ISO Local
+DATE_TIME_LOCAL_FORMAT = "%Y-%m-%dT%H:%M:%S"
+
+# ISO UTC
+DATE_TIME_UTC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
+
 # The default set of HTTP Status codes that will result in Query.get
 # returning a `None` value.
 #
@@ -16,3 +28,25 @@ HTTPERRORS_MAPPED_TO_NONE = (
     codes.GONE,       # 410
 )
 
+# A list of OK Response codes
+ACCEPTABLE_RESPONSE_STATUS_CODES = (
+    codes.ok,        # 200
+    codes.created,   # 201
+    codes.accepted,  # 202
+)
+
+ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "OPTIONS", ]
+
+JSON_CONTENT_TYPE = "application/json; charset=utf-8"
+
+# Resource Constants
+
+# Image Types
+IMAGE_TYPE_BANNER = "BANNER"
+IMAGE_TYPE_MAP = "MAP"
+IMAGE_TYPE_OTHER = "OTHER"
+IMAGE_TYPES = (
+    IMAGE_TYPE_BANNER,
+    IMAGE_TYPE_MAP,
+    IMAGE_TYPE_OTHER,
+)

--- a/gapipy/constants.py
+++ b/gapipy/constants.py
@@ -5,10 +5,10 @@ from requests.status_codes import codes
 # ISO Date
 DATE_FORMAT = "%Y-%m-%d"
 
-# ISO Local
+# ISO Date-Time Local
 DATE_TIME_LOCAL_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
-# ISO UTC
+# ISO Date-Time UTC
 DATE_TIME_UTC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 

--- a/gapipy/constants.py
+++ b/gapipy/constants.py
@@ -30,9 +30,9 @@ HTTPERRORS_MAPPED_TO_NONE = (
 
 # A list of OK Response codes
 ACCEPTABLE_RESPONSE_STATUS_CODES = (
-    codes.ok,        # 200
-    codes.created,   # 201
-    codes.accepted,  # 202
+    codes.OK,        # 200
+    codes.CREATED,   # 201
+    codes.ACCEPTED,  # 202
 )
 
 ALLOWED_METHODS = ["GET", "POST", "PUT", "PATCH", "OPTIONS", ]

--- a/gapipy/models/__init__.py
+++ b/gapipy/models/__init__.py
@@ -16,5 +16,3 @@ from .price_band import PriceBand, SeasonalPriceBand, PP2aPrice
 from .room import AccommodationRoom, DepartureRoom
 from .traveller_height import TravellerHeight
 from .valid_during_range import ValidDuringRange
-
-from .base import DATE_FORMAT, DATE_TIME_UTC_FORMAT, DATE_TIME_LOCAL_FORMAT

--- a/gapipy/models/base.py
+++ b/gapipy/models/base.py
@@ -4,15 +4,13 @@ from collections import namedtuple
 from copy import deepcopy
 from decimal import Decimal
 
+from gapipy.constants import DATE_FORMAT
+from gapipy.constants import DATE_TIME_LOCAL_FORMAT
+from gapipy.constants import DATE_TIME_UTC_FORMAT
 from gapipy.query import Query
-from gapipy.utils import (
-    get_resource_class_from_class_name,
-    get_resource_class_from_resource_name,
-)
+from gapipy.utils import get_resource_class_from_class_name
+from gapipy.utils import get_resource_class_from_resource_name
 
-DATE_FORMAT = '%Y-%m-%d'
-DATE_TIME_UTC_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
-DATE_TIME_LOCAL_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 # _Parent is a 3-Tuple that is used to store the based URI of a Resource, the
 # ID, and Variation ID if it has one

--- a/gapipy/query.py
+++ b/gapipy/query.py
@@ -3,26 +3,9 @@ from functools import wraps
 from itertools import islice
 
 from requests import HTTPError
-from requests.status_codes import codes
 
+from .constants import HTTPERRORS_MAPPED_TO_NONE
 from .request import APIRequestor
-
-
-# The default set of HTTP Status codes that will result in Query.get
-# returning a `None` value.
-#
-# Since 2.25.0 (See: https://github.com/gadventures/gapipy/pull/119)
-#
-# This is now passed as default parameter to `Query.get`. This has allowed
-# a slight modification to the behaviour of Resource.fetch, which now passes
-# in an explicit `None` value for `httperrors_mapped_to_none` kwarg.`Query.get`
-# will now raise the requests.HTTTPError when an attempt to `fetch` stub fails,
-# providing more expressive errors to be bubbled up.
-HTTPERRORS_MAPPED_TO_NONE = (
-    codes.FORBIDDEN,  # 403
-    codes.NOT_FOUND,  # 404
-    codes.GONE,       # 410
-)
 
 
 def _check_listable(func):

--- a/gapipy/request.py
+++ b/gapipy/request.py
@@ -1,20 +1,13 @@
 import sys
 from uuid import uuid1
 
-import requests
 from future.moves.urllib.parse import urlparse
 
+from gapipy.constants import ACCEPTABLE_RESPONSE_STATUS_CODES
+from gapipy.constants import ALLOWED_METHODS
+from gapipy.constants import JSON_CONTENT_TYPE
+
 from . import __title__, __version__
-
-ACCEPTABLE_RESPONSE_STATUS_CODES = (
-    requests.codes.ok,        # 200
-    requests.codes.created,   # 201
-    requests.codes.accepted,  # 202
-)
-
-ALLOWED_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'OPTIONS', ]
-
-JSON_CONTENT_TYPE = 'application/json'
 
 
 class APIRequestor(object):

--- a/gapipy/resources/tour/image.py
+++ b/gapipy/resources/tour/image.py
@@ -1,17 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from ..base import Resource
-from ...models.base import BaseModel
+from gapipy.models.base import BaseModel
+from gapipy.resources.base import Resource
 
-
-MAP_TYPE = 'MAP'
-OTHER_TYPE = 'OTHER'
-
-IMAGE_TYPES = (
-    MAP_TYPE,
-    OTHER_TYPE,
-)
 
 class ImageFile(BaseModel):
     _as_is_fields = [

--- a/gapipy/resources/tour/itinerary.py
+++ b/gapipy/resources/tour/itinerary.py
@@ -1,19 +1,18 @@
 # -*- coding: utf-8 -*-
-# Python 2 and 3
+
 # pylint: disable=no-member
 from __future__ import unicode_literals
 
+from gapipy.constants import IMAGE_TYPE_MAP
 from gapipy.models import ValidDuringRange
 from gapipy.models.base import BaseModel
 from gapipy.resources.base import Resource
 from gapipy.resources.booking_company import BookingCompany
-from gapipy.resources.tour.image import Image, MAP_TYPE
-from gapipy.utils import (
-    DurationLabelMixin,
-    LocationLabelMixin,
-    duration_label,
-    enforce_string_type,
-)
+from gapipy.resources.tour.image import Image
+from gapipy.utils import DurationLabelMixin
+from gapipy.utils import LocationLabelMixin
+from gapipy.utils import duration_label
+from gapipy.utils import enforce_string_type
 
 
 class RippleScore(BaseModel):
@@ -218,7 +217,7 @@ class Itinerary(Resource):
         None if no Images are listed, or if none are marked as a map image.
         """
         for image in self.images:
-            if getattr(image, 'type', None) == MAP_TYPE:
+            if image.type == IMAGE_TYPE_MAP:
                 return image
         return None
 

--- a/gapipy/resources/tour/tour.py
+++ b/gapipy/resources/tour/tour.py
@@ -1,11 +1,16 @@
-# Python 2 and 3
 from __future__ import unicode_literals
+
 import warnings
 
 from ..base import Resource
 from .departure import Departure
 from .tour_dossier import TourDossier
 
+
+_DEPRECATION_MESSAGE = (
+    "The `tours` resource has been deprecated in favour of the "
+    "`tour_dossiers` Rsource. This will be removed in the near future."
+)
 
 class Tour(Resource):
 
@@ -18,11 +23,7 @@ class Tour(Resource):
     _resource_collection_fields = [('departures', Departure)]
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("""
-            The `tours` resource will be deprecated in the near
-            future in favour of `tour_dossiers`. Please reference
-            `tour_dossiers` going forward
-        """, DeprecationWarning)
+        warnings.warn(_DEPRECATION_MESSAGE, DeprecationWarning)
         super(Tour, self).__init__(*args, **kwargs)
 
     def get_map_url(self):

--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
-# Python 2 and 3
 from __future__ import unicode_literals
 
+from gapipy.contants import IMAGE_TYPE_BANNER
+from gapipy.contants import IMAGE_TYPE_MAP
 from gapipy.models import AdvertisedDeparture, ValidDuringRange
 from gapipy.models.base import BaseModel
 from gapipy.resources.base import Resource
 from gapipy.resources.booking_company import BookingCompany
-
-
-# IMAGE_TYPE keys
-MAP_IMAGE_TYPE = 'MAP'
-BANNER_IMAGE_TYPE = 'BANNER'
 
 
 class TourDossierRelationship(BaseModel):
@@ -72,10 +68,10 @@ class TourDossier(Resource):
         return None
 
     def get_map_url(self):
-        return self._get_image_url(MAP_IMAGE_TYPE)
+        return self._get_image_url(IMAGE_TYPE_MAP)
 
     def get_banner_url(self):
-        return self._get_image_url(BANNER_IMAGE_TYPE)
+        return self._get_image_url(IMAGE_TYPE_BANNER)
 
     def get_visited_countries(self):
         return [country['name'] for country in self.geography['visited_countries']]

--- a/gapipy/resources/tour/tour_dossier.py
+++ b/gapipy/resources/tour/tour_dossier.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-from gapipy.contants import IMAGE_TYPE_BANNER
-from gapipy.contants import IMAGE_TYPE_MAP
+from gapipy.constants import IMAGE_TYPE_BANNER
+from gapipy.constants import IMAGE_TYPE_MAP
 from gapipy.models import AdvertisedDeparture, ValidDuringRange
 from gapipy.models.base import BaseModel
 from gapipy.resources.base import Resource

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-# Python 2 and 3
 from __future__ import unicode_literals
 
 import datetime
@@ -8,15 +7,14 @@ from unittest import TestCase
 from mock import patch
 
 from gapipy.client import Client
+from gapipy.constants import DATE_FORMAT
+from gapipy.models import AccommodationRoom
 from gapipy.query import Query
-from gapipy.models import DATE_FORMAT, AccommodationRoom
-from gapipy.resources import (
-    Departure,
-    Itinerary,
-    Promotion,
-    Tour,
-    TourDossier,
-)
+from gapipy.resources import Departure
+from gapipy.resources import Itinerary
+from gapipy.resources import Promotion
+from gapipy.resources import Tour
+from gapipy.resources import TourDossier
 from gapipy.resources.base import Resource
 
 from .fixtures import DUMMY_DEPARTURE, PPP_TOUR_DATA, PPP_DOSSIER_DATA


### PR DESCRIPTION
This commit introduces a new constats.py file which can be used by
downstream in their imports. eg;

```
from gapipy.constants import HTTPERRORS_MAPPED_TO_NONE
```

At the moment, no-one downstream needs this, but I'm planning a change
to the fetch() method, where it might be helpful for downstream clients
who want old functionality prior to 2.25.0

ref: #jwuw58