### PR TITLE
Add default timeout support to DjangoCache

### DIFF
--- a/gapipy/cache.py
+++ b/gapipy/cache.py
@@ -185,6 +185,7 @@ if django_settings:
             assert django_settings.CACHES is not None, "No CACHES found in django settings!"
             assert django_settings.CACHES.get('gapi') is not None, "No 'gapi' entry found in settings.CACHES!"
             self.client = django_caches['gapi']
+            super(DjangoCache, self).__init__(*args, **kwargs)
 
         def clear(self):
             self.client.clear()
@@ -200,6 +201,8 @@ if django_settings:
             return self.client.get(key)
 
         def set(self, key, value, timeout=None):
+            if timeout is None:
+                timeout = self.default_timeout
             self.client.set(key, value, timeout)
 
         def is_cached(self, key):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -68,6 +68,12 @@ class DjangoCacheTestCase(TestCase):
         self.client.set('test-key', 'test-value', 'test-timeout')
         self.mock_cache.set.assert_called_once_with('test-key', 'test-value', 'test-timeout')
 
+    def test_set__default_timeout(self):
+        """Should delegate 'set' operation to django cache client with default cache timeout."""
+        self.client.set('test-key', 'test-value', timeout=None)
+        self.mock_cache.set.assert_called_once_with('test-key', 'test-value', self.client.default_timeout)
+
+
 
 class SimpleCacheTestCase(TestCase):
 


### PR DESCRIPTION
I missed this when I implemented the class, so it's more of a bugfix.