### PR TITLE
Make future requirement flexible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-future==0.16.0
+future>=0.16.0
 requests>=2.18.4,<3.0.0


### PR DESCRIPTION
We've been using 0.18.2 with this for months on python2, but python 3.8's pip won't let us keep 0.18.2 because gapipy claims it only works with 0.16.0