### PR TITLE
Add Departure.travel_ready_policy model field

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,13 @@
 History
 =======
 
+2.34.0 (2021-08-20)
+-------------------
+
+* Add ``travel_ready_policy`` model field to the ``Departure`` resource.
+  * More details can be found in our `developer docs <https://developers.gadventures.com/docs/departure.html#travel-ready-policy>`
+
+
 2.33.0 (2021-07-06)
 -------------------
 

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -2,6 +2,6 @@
 
 __title__ = "gapipy"
 
-__version__ = "2.33.0"
+__version__ = "2.34.0"
 
 from .client import Client  # noqa

--- a/gapipy/resources/tour/departure.py
+++ b/gapipy/resources/tour/departure.py
@@ -11,6 +11,16 @@ from .tour_dossier import TourDossier
 from .departure_component import DepartureComponent
 
 
+class DepartureRelationship(BaseModel):
+    _as_is_fields = [
+        'type',
+        'sub_type',
+    ]
+    _resource_fields = [
+        ('departure', 'Departure'),
+    ]
+
+
 class LocalPayment(BaseModel):
     _as_is_fields = [
         'amount',
@@ -19,13 +29,10 @@ class LocalPayment(BaseModel):
     ]
 
 
-class DepartureRelationship(BaseModel):
+class TravelReadyPolicy(BaseModel):
     _as_is_fields = [
-        'type',
-        'sub_type',
-    ]
-    _resource_fields = [
-        ('departure', 'Departure'),
+        'code',
+        'name',
     ]
 
 
@@ -71,8 +78,9 @@ class Departure(Product):
         ('components', DepartureComponent),
     ]
     _model_fields = [
-        ('start_address', Address),
         ('finish_address', Address),
+        ('start_address', Address),
+        ('travel_ready_policy', TravelReadyPolicy),
     ]
     _model_collection_fields = [
         ('addons', AddOn),

--- a/gapipy/resources/tour/departure.py
+++ b/gapipy/resources/tour/departure.py
@@ -1,93 +1,102 @@
 # -*- coding: utf-8 -*-
-# Python 2 and 3
 from __future__ import unicode_literals
 
+from gapipy.models import AddOn
+from gapipy.models import Address
+from gapipy.models import DepartureRoom
+from gapipy.models import PP2aPrice
 from gapipy.models.base import BaseModel
-from gapipy.models import AddOn, Address, DepartureRoom, PP2aPrice
 from gapipy.resources.booking_company import BookingCompany
 from gapipy.resources.product import Product
 
-from .tour_dossier import TourDossier
 from .departure_component import DepartureComponent
+from .tour_dossier import TourDossier
 
 
 class DepartureRelationship(BaseModel):
     _as_is_fields = [
-        'type',
-        'sub_type',
+        "type",
+        "sub_type",
     ]
     _resource_fields = [
-        ('departure', 'Departure'),
+        ("departure", "Departure"),
     ]
 
 
 class LocalPayment(BaseModel):
     _as_is_fields = [
-        'amount',
-        'currency',
-        'label',
+        "amount",
+        "currency",
+        "label",
     ]
 
 
 class TravelReadyPolicy(BaseModel):
     _as_is_fields = [
-        'code',
-        'name',
+        "code",
+        "name",
     ]
 
 
 class Departure(Product):
 
-    _resource_name = 'departures'
+    _resource_name = "departures"
 
     _is_listable = True
 
     _is_parent_resource = True
 
     _as_is_fields = [
-        'id',
-        'href',
-        'name',
-        'availability',
-        'flags',
-        'nearest_start_airport',
-        'nearest_finish_airport',
-        'product_line',
-        'sku',
-        'requirements',
-        'program',
+        "availability",
+        "flags",
+        "href",
+        "id",
+        "name",
+        "nearest_finish_airport",
+        "nearest_start_airport",
+        "product_line",
+        "program",
+        "requirements",
+        "sku",
     ]
+
     _date_fields = [
-        'start_date',
-        'finish_date',
+        "finish_date",
+        "start_date",
     ]
+
     _date_time_fields_utc = [
-        'date_created',
-        'date_last_modified',
-        'date_cancelled',
+        "date_cancelled",
+        "date_created",
+        "date_last_modified",
     ]
+
     _date_time_fields_local = [
-        'latest_arrival_time',
-        'earliest_departure_time',
+        "earliest_departure_time",
+        "latest_arrival_time",
     ]
+
     _resource_fields = [
-        ('tour', 'Tour'),
-        ('tour_dossier', TourDossier),
+        ("tour_dossier", TourDossier),
+        ("tour", "Tour"),
     ]
+
     _resource_collection_fields = [
-        ('components', DepartureComponent),
+        ("components", DepartureComponent),
     ]
+
     _model_fields = [
-        ('finish_address', Address),
-        ('start_address', Address),
-        ('travel_ready_policy', TravelReadyPolicy),
+        ("finish_address", Address),
+        ("start_address", Address),
+        ("travel_ready_policy", TravelReadyPolicy),
     ]
+
     _model_collection_fields = [
-        ('addons', AddOn),
-        ('booking_companies', BookingCompany),
-        ('local_payments', LocalPayment),
-        ('lowest_pp2a_prices', PP2aPrice),
-        ('relationships', DepartureRelationship),
-        ('rooms', DepartureRoom),
-        ('structured_itineraries', 'Itinerary'),
+        ("addons", AddOn),
+        ("booking_companies", BookingCompany),
+        ("local_payments", LocalPayment),
+        ("lowest_pp2a_prices", PP2aPrice),
+        ("relationships", DepartureRelationship),
+        ("rooms", DepartureRoom),
+        ("structured_itineraries", "Itinerary"),
     ]


### PR DESCRIPTION
Adds the `travel_ready_policy` field to the `Departure` Resource.

This field will have two accessible attributes: `code` and `name`

```python
departure = gapi.departures.get(999999)

departure.travel_ready_policy.code
departure.travel_ready_policy.name
```

The currrent set of `code` values will be:
* `COVID_VACCINATED` - Travellers must be fully vaccinated 14 days prior to the start of the departure
* `COVID_VACCINATED_OR_PCR_TEST` - Travellers must be fully vaccinated 14 days prior to the start of the departure OR a negative PCR test within 96 hours (4 days) of the start of the departure.
* `NO_POLICY`

More details can be found on our [developers documentation](https://developers.gadventures.com/docs/departure.html#travel-ready-policy):