### PR TITLE
Detect an empty payload during a partial update...

### DIFF
--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -24,6 +24,7 @@ default_config = {
     },
     'debug': os.environ.get('GAPI_CLIENT_DEBUG', False),
     'max_retries': os.environ.get('GAPI_CLIENT_MAX_RETRIES', 0),
+    'raise_on_noop_update': os.environ.get('GAPI_CLIENT_RAISE_ON_NOOP_UPDATE', False),
     'uuid': os.environ.get('GAPI_UUID', False),
     # we don't have a nice way to intialise a dictionary from the environment,
     # so we default it to an empty dict here.
@@ -56,6 +57,7 @@ class Client(object):
         self.cache_backend = get_config(config, 'cache_backend')
         self.global_http_headers = get_config(config, 'global_http_headers')
         self.max_retries = get_config(config, 'max_retries')
+        self.raise_on_noop_update = get_config(config, 'raise_on_noop_update')
         self.uuid = get_config(config, 'uuid')
 
         # begin with default connection pool options and with overwrite any

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -5,7 +5,7 @@ from importlib import import_module
 
 from .utils import get_available_resource_classes
 
-# intialise logger
+# initialise logger
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -5,10 +5,12 @@ from importlib import import_module
 
 from .utils import get_available_resource_classes
 
-
+# intialise logger
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.StreamHandler())
 
+
+# the default configuration dict with values pulled from the environment
 default_config = {
     'api_language': os.environ.get('GAPI_LANGUAGE'),
     'api_proxy': os.environ.get('GAPI_API_PROXY', ''),
@@ -60,8 +62,8 @@ class Client(object):
         self.raise_on_noop_update = get_config(config, 'raise_on_noop_update')
         self.uuid = get_config(config, 'uuid')
 
-        # begin with default connection pool options and with overwrite any
-        # configuration options the client has specified
+        # begin with default connection pool options and override them with
+        # the configuration options the client has specified
         self.connection_pool_options = default_config['connection_pool_options']
         self.connection_pool_options.update(get_config(config, 'connection_pool_options'))
 

--- a/gapipy/client.py
+++ b/gapipy/client.py
@@ -26,7 +26,7 @@ default_config = {
     },
     'debug': os.environ.get('GAPI_CLIENT_DEBUG', False),
     'max_retries': os.environ.get('GAPI_CLIENT_MAX_RETRIES', 0),
-    'raise_on_noop_update': os.environ.get('GAPI_CLIENT_RAISE_ON_NOOP_UPDATE', False),
+    'raise_on_empty_update': os.environ.get('GAPI_CLIENT_RAISE_ON_EMPTY_UPDATE', False),
     'uuid': os.environ.get('GAPI_UUID', False),
     # we don't have a nice way to intialise a dictionary from the environment,
     # so we default it to an empty dict here.
@@ -59,7 +59,7 @@ class Client(object):
         self.cache_backend = get_config(config, 'cache_backend')
         self.global_http_headers = get_config(config, 'global_http_headers')
         self.max_retries = get_config(config, 'max_retries')
-        self.raise_on_noop_update = get_config(config, 'raise_on_noop_update')
+        self.raise_on_empty_update = get_config(config, 'raise_on_empty_update')
         self.uuid = get_config(config, 'uuid')
 
         # begin with default connection pool options and override them with

--- a/gapipy/exceptions.py
+++ b/gapipy/exceptions.py
@@ -3,7 +3,6 @@
 
 class GapipyException(Exception):
     """Generic base-class for all gapipy exception-types."""
-    pass
 
 
 class EmptyPartialUpdateError(ValueError, GapipyException):

--- a/gapipy/exceptions.py
+++ b/gapipy/exceptions.py
@@ -1,8 +1,16 @@
+"""gapipy exception types"""
+
 
 class GapipyException(Exception):
+    """Generic base-class for all gapipy exception-types."""
     pass
 
 
-class EmptyPartialUpdateException(GapipyException):
-    def __str__(self):
-        return "gapipy computed no changes for partial update"
+class EmptyPartialUpdateError(ValueError, GapipyException):
+    """A partial update of a resource was requested, but no data has changed."""
+    def __init__(self, *args):
+        """Initialize with a default message if the caller hasn't supplied anything."""
+        if not args:
+            args = ("gapipy computed no changes for partial update",)
+
+        super(EmptyPartialUpdateError, self).__init__(*args)

--- a/gapipy/exceptions.py
+++ b/gapipy/exceptions.py
@@ -1,0 +1,8 @@
+
+class GapipyException(Exception):
+    pass
+
+
+class EmptyPartialUpdateException(GapipyException):
+    def __str__(self):
+        return "gapipy computed no changes for partial update"

--- a/gapipy/models/base.py
+++ b/gapipy/models/base.py
@@ -104,15 +104,15 @@ class BaseModel(object):
     def _model_cls(self, field):
         # Find what model class this field is in reference to by plucking it
         # from the set of all fields that allow this type of definition.
-        fields = (
-            self._model_fields
-            + self._model_collection_fields
-            + self._resource_fields
-            + self._resource_collection_fields
-        )
+        fields = (self._model_fields
+                  + self._model_collection_fields
+                  + self._resource_fields
+                  + self._resource_collection_fields)
+
         model_cls = [cls for f, cls in fields if f == field][0]
 
         # FIXME: This will not work for the model_*_fields.
+
         # Python 2 has basestring, Python 3 str
         str_or_base = False
         if sys.version_info.major < 3:

--- a/gapipy/models/base.py
+++ b/gapipy/models/base.py
@@ -104,15 +104,15 @@ class BaseModel(object):
     def _model_cls(self, field):
         # Find what model class this field is in reference to by plucking it
         # from the set of all fields that allow this type of definition.
-        fields = (self._model_fields
-                  + self._model_collection_fields
-                  + self._resource_fields
-                  + self._resource_collection_fields)
-
+        fields = (
+            self._model_fields
+            + self._model_collection_fields
+            + self._resource_fields
+            + self._resource_collection_fields
+        )
         model_cls = [cls for f, cls in fields if f == field][0]
 
         # FIXME: This will not work for the model_*_fields.
-
         # Python 2 has basestring, Python 3 str
         str_or_base = False
         if sys.version_info.major < 3:

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import json
 import logging
 
+from gapipy.exceptions import EmptyPartialUpdateException
 from gapipy.models.base import BaseModel
 from gapipy.request import APIRequestor
 from gapipy.utils import enforce_string_type
@@ -105,7 +106,7 @@ class Resource(BaseModel):
         if partial:
             data = {k: v for k, v in data.items() if self._raw_data.get(k) != v}
             if not data:
-                raise ValueError("gapipy computed no changes for this partial update")
+                raise EmptyPartialUpdateException
 
         return request.update(self.id, json.dumps(data), partial=partial)
 
@@ -125,7 +126,7 @@ class Resource(BaseModel):
             #                 as such.
             try:
                 result = self._update(partial=partial)
-            except ValueError:
+            except EmptyPartialUpdateException:
                 if self._client.raise_on_empty_update:
                     raise
                 return self

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -102,7 +102,7 @@ class Resource(BaseModel):
         # the G API.
         #
         # Added (2.35.0): If the change computed results in an empty data
-        #                 dictionary we'll raise a ValueError
+        #                 dictionary we'll raise a EmptyPartialUpdateError
         if partial:
             data = {k: v for k, v in data.items() if self._raw_data.get(k) != v}
             if not data:

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 import json
 import logging
 
-from gapipy.exceptions import EmptyPartialUpdateException
+from gapipy.exceptions import EmptyPartialUpdateError
 from gapipy.models.base import BaseModel
 from gapipy.request import APIRequestor
 from gapipy.utils import enforce_string_type
@@ -106,7 +106,7 @@ class Resource(BaseModel):
         if partial:
             data = {k: v for k, v in data.items() if self._raw_data.get(k) != v}
             if not data:
-                raise EmptyPartialUpdateException
+                raise EmptyPartialUpdateError
 
         return request.update(self.id, json.dumps(data), partial=partial)
 
@@ -126,7 +126,7 @@ class Resource(BaseModel):
             #                 as such.
             try:
                 result = self._update(partial=partial)
-            except EmptyPartialUpdateException:
+            except EmptyPartialUpdateError:
                 if self._client.raise_on_empty_update:
                     raise
                 return self

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -123,7 +123,7 @@ class Resource(BaseModel):
         if is_update:
             # Added (2.35.0): we check if a partial update threw an exception
             #                 and re-raise it if the client has been configured
-            #                 as such.
+            #                 to do so via raise_on_empty_update config option.
             try:
                 result = self._update(partial=partial)
             except EmptyPartialUpdateError:

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -101,11 +101,9 @@ class Resource(BaseModel):
 
         # when making a partial (PATCH) request, ensure we only include values
         # changed on self compared to the initial raw response received from
-        # the G API
+        # the G API.
         if partial:
-            # NOTE: dict.items is not effecient in Python 2
             data = {k: v for k, v in data.items() if self._raw_data.get(k) != v}
-
             if not data:
                 # Added in 2.x.x: we check if a partial request generates a noop
                 # update payload and raise an error if the client has explicitly

--- a/gapipy/resources/base.py
+++ b/gapipy/resources/base.py
@@ -131,7 +131,7 @@ class Resource(BaseModel):
             result = self._create()
 
         # check if we returned a NOOP_UPDATE response, and exit early to avoid
-        # caling _fill_fields
+        # calling _fill_fields
         if result is NOOP_UPDATE:
             return self
 


### PR DESCRIPTION
... and either make it a no-op or raise an exception, based on client configs.

Introduces a new client config which defaults to `False`:
- `raise_on_empty_update` if passed into the client's `__init__`, or
- `GAPI_CLIENT_RAISE_ON_EMPTY_UPDATE` if passed as an env var

Introduces new exception types:
- `gapipy.exceptions.GapipyException`
- `gapipy.exceptions.EmptyPartialUpdateError`

--

The behaviour prior to this change of performing a
`resource.save(partial=True)` without having made any changes to the
data was:
- gapipy makes a PATCH request with an empty-dict payload
- GAPI responds with an HTTP 400 and the message
`You must provide fields to PATCH`

With the changes in this PR, instead gapipy will see the payload would be
empty and decide not to send that PATCH. If the client's
`raise_on_empty_update` config is falsey (the default) it will be a no-op;
if the client's `raise_on_empty_update` config is truthy, it will raise a
`EmptyPartialUpdateError`

--

Addresses #136