### PR TITLE
Run unit tests GH Actions with tox

### DIFF
--- a/.github/workflows/tox-unit-tests.yml
+++ b/.github/workflows/tox-unit-tests.yml
@@ -17,7 +17,6 @@ jobs:
         - '3.7'
         - '3.8'
         - '3.9'
-        - '3.10'
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/tox-unit-tests.yml
+++ b/.github/workflows/tox-unit-tests.yml
@@ -1,0 +1,27 @@
+name: Run unit tests with tox
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['2.7', '3.9']
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install tox==3.25.0 tox-gh-actions==2.9.1
+    - name: Run tox (excluding integration tests)
+      env:
+        NOSE_ARGS: -A integration!=1
+      run: tox

--- a/.github/workflows/tox-unit-tests.yml
+++ b/.github/workflows/tox-unit-tests.yml
@@ -9,7 +9,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['2.7', '3.9']
+        # Note that this list of versions should correspond with what's in tox.ini
+        python-version:
+        - '2.7'
+        - '3.5'
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
 
     steps:
     - uses: actions/checkout@v1

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
 mock==1.0.1 ; python_version < '3.0'
-nose==1.3.3
+nose==1.3.7
 nose-parameterized==0.3.3

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
 
-mock==1.0.1
+mock==1.0.1 ; python_version < '3.0'
 nose==1.3.3
 nose-parameterized==0.3.3

--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,6 @@ with open("requirements.txt") as reqs:
         if line:
             requirements.append(line.strip("\n"))
 
-test_requirements = [
-    "mock",
-    "nose",
-    "nose-parameterized",
-]
-
 setup(
     name="gapipy",
     version=gapipy.__version__,
@@ -53,6 +47,4 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    tests_require=test_requirements,
-    test_suite="nose.collector",
 )

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,9 +1,12 @@
 import time
 from unittest import TestCase, skip, skipUnless
 
-import mock
-
 from gapipy import cache
+
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
 
 try:
     from django.test import override_settings

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -49,7 +49,7 @@ class DjangoCacheTestCase(TestCase):
     def test_clear(self):
         """Should delegate 'clear' operation to django cache client."""
         self.client.clear()
-        self.mock_cache.clear.assert_called_once()
+        self.assertEqual(len(self.mock_cache.clear.mock_calls), 1)
 
     def test_delete(self):
         """Should delegate 'delete' operation to django cache client."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,11 +1,15 @@
 import json
-from mock import patch
 import unittest
 
 from gapipy.client import Client
 from gapipy.query import Query
 from gapipy.resources.base import Resource
 from gapipy.utils import get_available_resource_classes
+
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
 
 
 class ClientTestCase(unittest.TestCase):
@@ -37,7 +41,7 @@ class ClientTestCase(unittest.TestCase):
         self.assertEqual(resource.id, 1)
         self.assertEqual(resource.foo, 'bar')
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_create_interface(self, mock_request):
         class MockResource(Resource):
             _as_is_fields = ['id', 'foo']
@@ -55,7 +59,7 @@ class ClientTestCase(unittest.TestCase):
         resource = self.gapi.create('foo', {'id': 1, 'foo': 'bar', 'context': 'abc'})
         self.assertEqual(resource.id, 1)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_create_extra_headers(self, mock_request):
         """
         Test that extra HTTP headers can be passed through the `.create`
@@ -81,7 +85,7 @@ class ClientTestCase(unittest.TestCase):
             additional_headers=extra_headers,
         )
 
-    @patch('gapipy.query.Query.get_resource_data')
+    @mock.patch('gapipy.query.Query.get_resource_data')
     def test_correct_client_is_associated_with_resources(self, mock_get_data):
         mock_get_data.return_value = {
             'id': 123

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -2,7 +2,6 @@ import json
 import sys
 import unittest
 
-from mock import MagicMock, patch
 from requests import HTTPError, Response
 
 from gapipy.client import Client
@@ -14,6 +13,11 @@ from gapipy.utils import get_available_resource_classes
 from .fixtures import (
     PPP_TOUR_DATA, TOUR_DOSSIER_LIST_DATA, DUMMY_DEPARTURE, DUMMY_PROMOTION,
 )
+
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
 
 
 class QueryKeyTestCase(unittest.TestCase):
@@ -106,13 +110,13 @@ class QueryTestCase(unittest.TestCase):
         self.cache = self.client._cache
         self.cache.clear()
 
-    @patch('gapipy.request.APIRequestor._request', return_value=PPP_TOUR_DATA)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=PPP_TOUR_DATA)
     def test_get_instance_by_id(self, mock_request):
         query = Query(self.client, Tour)
         t = query.get(1234)
         self.assertIsInstance(t, Tour)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_get_instance_with_forbidden_id(self, mock_request):
         response = Response()
         response.status_code = 403
@@ -132,7 +136,7 @@ class QueryTestCase(unittest.TestCase):
             context.exception.response.status_code,
             response.status_code)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_get_instance_with_non_existing_id(self, mock_request):
         response = Response()
         response.status_code = 404
@@ -152,7 +156,7 @@ class QueryTestCase(unittest.TestCase):
             context.exception.response.status_code,
             response.status_code)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_get_instance_with_gone_id(self, mock_request):
         response = Response()
         response.status_code = 410
@@ -172,7 +176,7 @@ class QueryTestCase(unittest.TestCase):
             context.exception.response.status_code,
             response.status_code)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_get_instance_by_id_with_non_404_error(self, mock_request):
         response = Response()
         response.status_code = 401
@@ -194,7 +198,7 @@ class QueryTestCase(unittest.TestCase):
         self.assertIsNone(
             query.get(1234, httperrors_mapped_to_none=[response.status_code]))
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_filtered_query_returns_new_object(self, mock_request):
         """
         Arguments passed to .filter() are stored on new (copied) Query instance
@@ -208,7 +212,7 @@ class QueryTestCase(unittest.TestCase):
         self.assertFalse(query is query1)
         self.assertNotEqual(query._filters, query1._filters)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_filtered_query(self, mock_request):
         """
         Arguments passed to .filter() are stored on new (copied) Query instance
@@ -241,7 +245,7 @@ class QueryTestCase(unittest.TestCase):
         query.count()
         self.assertEqual(len(query._filters), 2)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_query_persist_filter_on_count(self, mock_request):
         query = Query(self.client, Tour)
         my_query = query.filter(tour_dossier_code='PPP')
@@ -261,26 +265,26 @@ class QueryTestCase(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, message):
                 Query(self.client, Activity).count()
 
-    @patch('gapipy.request.APIRequestor._request', return_value=DUMMY_PROMOTION)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=DUMMY_PROMOTION)
     def test_can_retrieve_single_non_listable_resource(self, mock_request):
         Query(self.client, Activity).get(1234)
         mock_request.assert_called_once_with(
             '/activities/1234', 'GET', additional_headers=None)
 
-    @patch('gapipy.request.APIRequestor._request', return_value=DUMMY_DEPARTURE)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=DUMMY_DEPARTURE)
     def test_can_retrieve_single_subresource_without_parent(self, mock_request):
         Query(self.client, Departure).get(1234)
         mock_request.assert_called_once_with(
             '/departures/1234', 'GET', additional_headers=None)
 
-    @patch('gapipy.request.APIRequestor._request', return_value=TOUR_DOSSIER_LIST_DATA)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=TOUR_DOSSIER_LIST_DATA)
     def test_count(self, mock_request):
         query = Query(self.client, TourDossier)
         count = query.count()
         self.assertIsInstance(count, int)
         self.assertEqual(count, 3)
 
-    @patch('gapipy.request.APIRequestor._request', return_value=TOUR_DOSSIER_LIST_DATA)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=TOUR_DOSSIER_LIST_DATA)
     def test_fetch_all(self, mock_request):
 
         query = Query(self.client, TourDossier).all()
@@ -296,7 +300,7 @@ class QueryTestCase(unittest.TestCase):
         mock_request.assert_called_once_with(
             '/tour_dossiers', 'GET', params={})
 
-    @patch('gapipy.request.APIRequestor._request', return_value=TOUR_DOSSIER_LIST_DATA)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=TOUR_DOSSIER_LIST_DATA)
     def test_fetch_all_with_limit(self, mock_request):
 
         query = Query(self.client, TourDossier).all(limit=2)
@@ -341,7 +345,7 @@ class QueryCacheTestCase(unittest.TestCase):
         self.cache = self.client._cache
         self.cache.clear()
 
-    @patch('gapipy.request.APIRequestor._request', return_value=PPP_TOUR_DATA)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=PPP_TOUR_DATA)
     def test_resources_are_cached(self, mock_request):
         query = Query(self.client, Tour)
 
@@ -367,10 +371,10 @@ class QueryCacheTestCase(unittest.TestCase):
         query = Query(self.client, Tour)
 
         # act like we already have the data in our cache
-        mock_cache_get = MagicMock(return_value=PPP_TOUR_DATA)
+        mock_cache_get = mock.MagicMock(return_value=PPP_TOUR_DATA)
         self.cache.get = mock_cache_get
 
-        mock_cache_set = MagicMock()
+        mock_cache_set = mock.MagicMock()
         self.cache.set = mock_cache_set
 
         query.get(21346)
@@ -383,7 +387,7 @@ class MockResource(Resource):
     _resource_name = 'mocks'
 
 
-@patch('gapipy.request.APIRequestor._request')
+@mock.patch('gapipy.request.APIRequestor._request')
 class UpdateCreateResourceTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,13 +1,16 @@
 import sys
 import unittest
 
-from mock import call, patch
-
 from gapipy.client import Client
 from gapipy.models.base import _Parent
 from gapipy.request import APIRequestor
 
 from .fixtures import FIRST_PAGE_LIST_DATA, SECOND_PAGE_LIST_DATA
+
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
 
 
 class Resources(object):
@@ -21,13 +24,13 @@ class APIRequestorTestCase(unittest.TestCase):
         self.client = Client()
         self.resources = Resources(_resource_name='resources', _uri=None)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_get_resource_by_id(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.get(1234)
         mock_request.assert_called_once_with('/resources/1234', 'GET', additional_headers=None)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_get_with_null_resource_id_and_uri_raises_error(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         error_msg = 'Need to provide at least one of `resource_id` or `uri` as argument'
@@ -38,45 +41,45 @@ class APIRequestorTestCase(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, error_msg):
                 requestor.get()
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_get_with_falsy_resource_id_does_not_raise_error(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.get(0)
         mock_request.assert_called_once_with('/resources/0', 'GET', additional_headers=None)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_list_resource(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.list_raw()
         mock_request.assert_called_once_with('/resources', 'GET', params=None)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_list_raw_uri_requestor_params(self, mock_request):
         params = {'param': 'value'}
         requestor = APIRequestor(self.client, self.resources, params=params)
         requestor.list_raw('/test_uri')
         mock_request.assert_called_once_with('/test_uri', 'GET', params=params)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_list_raw_uri_no_requestor_params(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.list_raw('/test_uri')
         mock_request.assert_called_once_with('/test_uri', 'GET', params=None)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_list_raw_uri_params_requestor_params(self, mock_request):
         params = {'param': 'value'}
         requestor = APIRequestor(self.client, self.resources, params=params)
         requestor.list_raw('/test_uri?')
         mock_request.assert_called_once_with('/test_uri?', 'GET', params=params)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_list_raw_uri_params_no_requestor_params(self, mock_request):
         requestor = APIRequestor(self.client, self.resources)
         requestor.list_raw('/test_uri?')
         mock_request.assert_called_once_with('/test_uri?', 'GET', params=None)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_list_resource_with_parent(self, mock_request):
         parent = _Parent('parent', '1234', None)
         requestor = APIRequestor(self.client, self.resources, parent=parent)
@@ -84,12 +87,12 @@ class APIRequestorTestCase(unittest.TestCase):
         mock_request.assert_called_once_with(
             '/parent/1234/resources', 'GET', params=None)
 
-    @patch('gapipy.request.APIRequestor.list_raw')
+    @mock.patch('gapipy.request.APIRequestor.list_raw')
     def test_list_generator(self, mock_list):
         mock_list.side_effect = [FIRST_PAGE_LIST_DATA, SECOND_PAGE_LIST_DATA]
         expected_calls = [
-            call(None),
-            call('http://localhost:5000/resources/?page=2'),
+            mock.call(None),
+            mock.call('http://localhost:5000/resources/?page=2'),
         ]
 
         requestor = APIRequestor(self.client, self.resources)
@@ -98,7 +101,7 @@ class APIRequestorTestCase(unittest.TestCase):
         self.assertEqual(mock_list.mock_calls, expected_calls)
         self.assertEqual(len(resources), 6)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_uuid_not_set(self, mock_request):
         self.client.uuid = False
         requestor = APIRequestor(self.client, self.resources)
@@ -106,7 +109,7 @@ class APIRequestorTestCase(unittest.TestCase):
         requestor.list_raw()
         mock_request.assert_called_once_with('/resources', 'GET', params={'test': '1234'})
 
-    @patch('gapipy.request.APIRequestor._make_call')
+    @mock.patch('gapipy.request.APIRequestor._make_call')
     def test_uuid_set(self, mock_make_call):
         self.client.uuid = True
         requestor = APIRequestor(self.client, self.resources)
@@ -114,7 +117,7 @@ class APIRequestorTestCase(unittest.TestCase):
         params_arg = mock_make_call.call_args[0][-1]
         self.assertTrue('uuid' in params_arg)
 
-    @patch('gapipy.request.APIRequestor._make_call')
+    @mock.patch('gapipy.request.APIRequestor._make_call')
     def test_uuid_with_other_params(self, mock_make_call):
         self.client.uuid = True
         requestor = APIRequestor(self.client, self.resources)

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 import datetime
 from unittest import TestCase
 
-from mock import patch
-
 from gapipy.client import Client
 from gapipy.constants import DATE_FORMAT
 from gapipy.models import AccommodationRoom
@@ -19,6 +17,10 @@ from gapipy.resources.base import Resource
 
 from .fixtures import DUMMY_DEPARTURE, PPP_TOUR_DATA, PPP_DOSSIER_DATA
 
+try:
+    from unittest import mock  # Python 3
+except ImportError:
+    import mock  # Python 2
 
 class ResourceTestCase(TestCase):
 
@@ -44,7 +46,7 @@ class ResourceTestCase(TestCase):
         self.assertEqual(data['date_field'], '2013-02-18')
         self.assertEqual(data['date_field_utc'], '2013-02-18T18:17:20Z')
 
-    @patch('gapipy.request.APIRequestor._request', return_value=PPP_DOSSIER_DATA)
+    @mock.patch('gapipy.request.APIRequestor._request', return_value=PPP_DOSSIER_DATA)
     def test_instantiate_from_raw_data(self, _):
         t = Tour(PPP_TOUR_DATA, client=self.client)
         self.assertIsInstance(t, Tour)
@@ -53,7 +55,7 @@ class ResourceTestCase(TestCase):
         self.assertIsInstance(t.tour_dossier, TourDossier)
         self.assertIsInstance(t.departures, Query)
 
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_populate_stub(self, mock_fetch):
         mock_fetch.return_value = {
             'id': 1,
@@ -164,7 +166,7 @@ class AccommodationRoomTestCase(TestCase):
 
 
 class PromotionTestCase(TestCase):
-    @patch('gapipy.request.APIRequestor._request')
+    @mock.patch('gapipy.request.APIRequestor._request')
     def test_product_type_is_set_properly(self, mock_request):
         data = {
             'products': [

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -83,7 +83,8 @@ class ResourceTestCase(TestCase):
         # Force a fetch.
         assert t.departures_start_date
 
-        mock_fetch.assert_called_once()
+        self.assertEqual(len(mock_fetch.mock_calls), 1)
+
         self.assertFalse(t.is_stub)
         self.assertEqual(
             t.departures_start_date,

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 envlist = py27,py39
 skip_missing_interpreters = True
 
+[gh-actions]
+python =
+    2.7: py27
+    3.9: py39
+
 [testenv]
 commands =
     pip install -r requirements-testing.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py27,py35,py36
+envlist = py27,py39
 skip_missing_interpreters = True
 
 [testenv]
 commands =
     pip install -r requirements-testing.txt
-    python setup.py test
-passenv = GAPI_APPLICATION_KEY
+    nosetests {env:NOSE_ARGS:}
+passenv = GAPI_APPLICATION_KEY NOSE_ARGS

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,16 @@
 [tox]
-envlist = py27,py39
+envlist = py{27,35,36,37,38,39,310}
 skip_missing_interpreters = True
 
 [gh-actions]
 python =
     2.7: py27
+    3.5: py35
+    3.6: py36
+    3.7: py37
+    3.8: py38
     3.9: py39
+    3.10: py310
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37,38,39,310}
+envlist = py{27,35,36,37,38,39}
 skip_missing_interpreters = True
 
 [gh-actions]
@@ -11,7 +11,6 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310
 
 [testenv]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py{27,35,36,37,38,39,310}
 skip_missing_interpreters = True
 
 [gh-actions]
+# Note that this list of versions should correspond with what's in the GH workflow config
 python =
     2.7: py27
     3.5: py35


### PR DESCRIPTION
## Discussion questions:

### Which triggers should we use for this action?

It is currently on `push` and `pull_request` but maybe that's redundant?

### Which Pythons do we actually need to support?

2.7 and 3.5 through 3.9 run OK without _too much_ fuss.

Officially, only 3.7+ are supported today, but I know we've got some use-cases that are behind the times.

We're currently using `nose` as our test runner, but it doesn't support 3.10 [0,1,2] -- we'll have to deal with that at some point, but _maaaaybe_ not today? Thoughts?

I'm not sure we use many nose-specific features: some marks to indicate which tests are "integration" and also some parametrization in those integration tests (that we won't run on push/PRs anyway).

pytest is nice, but it doesn't support 2.7.

Oh, I guess nose2 [3] is a thing but I don't know much about it other than that the README claims it supports 2.7 and 3.6-3.10

### Does anybody care about running tests for Windows/MacOS?

Seems supported by Actions, but IDK if it's simple or necessary 🤷 

[0] https://github.com/nose-devs/nose/issues/1122
[1] https://github.com/nose-devs/nose/issues/1118
[2] https://github.com/gadventures/gapipy/runs/6015009047?check_suite_focus=true#step:5:63
[3] https://github.com/nose-devs/nose2