### PR TITLE
Add "contact_us" model field to the AgencyChain resource

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,17 @@
 History
 =======
 
+2.36.0 (unreleased)
+-------------------
+
+* Add ``contact_us`` field to the ``AgenchChain`` resource. This field can be
+  ``None``, however should a value be present, it will be an object with three
+  accessible attributes: ``email``, ``phone_number``, and ``website_url``. See
+  the `PR #141`_ for more details.
+
+.. _`PR #141`: https://github.com/gadventures/gapipy/pull/141
+
+
 2.35.0 (2022-04-18)
 -------------------
 

--- a/gapipy/__init__.py
+++ b/gapipy/__init__.py
@@ -2,6 +2,6 @@
 
 __title__ = "gapipy"
 
-__version__ = "2.35.0"
+__version__ = "2.36.0"
 
 from .client import Client  # noqa

--- a/gapipy/resources/booking/agency_chain.py
+++ b/gapipy/resources/booking/agency_chain.py
@@ -2,7 +2,16 @@
 from __future__ import unicode_literals
 
 from gapipy.resources.base import Resource
+from gapipy.resources.base import BaseModel
 from gapipy.resources.booking_company import BookingCompany
+
+
+class ContactUs(BaseModel):
+    _as_is_fields = [
+        "email",
+        "phone_number",
+        "website_url",
+    ]
 
 
 class AgencyChain(Resource):
@@ -24,6 +33,10 @@ class AgencyChain(Resource):
     _date_time_fields_local = [
         "date_created",
         "date_last_modified",
+    ]
+
+    _model_fields = [
+        ("contact_us", ContactUs),
     ]
 
     _resource_fields = [


### PR DESCRIPTION
The new field contains three attributes; `email`, `phone_number`, and `website_url`; which provide corresponding "contact us" values.

This will be released as version `2.36.0`

NOTE: This field will be `None` (`null`) if all of the contained fields have `None` values.

### Usage:

```python
In [1]: from gapipy import Client

In [2]: gapi = Client(application_key="test_abcd...")

In [3]: ac = gapi.agency_chains.get("a1234000000ABCDEF4")  # null contact_us

In [4]: ac.contact_us is None
Out [4]: True

In [5]: ac = gapi.agency_chains.get("a1234000000ABCDEF5")  # non-null contact_us

In [6]: ac.contact_us
Out[6]: <gapipy.resources.booking.agency_chain.ContactUs at 0x1053a9760>

In [7]: ac.contact_us.website_url
Out[7]: 'https://www.example.com/contact-us'

In [8]: ac._raw_data['contact_us']
Out[8]:
{'email': None,
 'phone_number': None,
 'website_url': 'https://www.example.com/contact-us'}
