### PR TITLE
Remove unsupported Python versions from testing matrix

### DIFF
--- a/.github/workflows/tox-unit-tests.yml
+++ b/.github/workflows/tox-unit-tests.yml
@@ -11,10 +11,6 @@ jobs:
       matrix:
         # Note that this list of versions should correspond with what's in tox.ini
         python-version:
-        - '2.7'
-        - '3.5'
-        - '3.6'
-        - '3.7'
         - '3.8'
         - '3.9'
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,10 @@
 [tox]
-envlist = py{27,35,36,37,38,39}
+envlist = py{38,39}
 skip_missing_interpreters = True
 
 [gh-actions]
 # Note that this list of versions should correspond with what's in the GH workflow config
 python =
-    2.7: py27
-    3.5: py35
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
 


### PR DESCRIPTION
These versions are not supported by GitHub Actions anymore, and so the CI checks always fail.

The same thing will probably happen with Python 3.8. But this should buy us some time until the tests can be rewritten to support more modern version of Python.